### PR TITLE
feat: UI/UX improvements — dashboard, calendar, appointments, navigation

### DIFF
--- a/src/app/(dashboard)/appointments/loading.tsx
+++ b/src/app/(dashboard)/appointments/loading.tsx
@@ -1,46 +1,54 @@
 import { Skeleton } from "@/components/ui/skeleton"
-import { Card, CardContent } from "@/components/ui/card"
+import { Card } from "@/components/ui/card"
 
 export default function AppointmentsLoading() {
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-7 w-36" />
-          <Skeleton className="h-5 w-8" />
+        <div>
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="h-6 w-36" />
+            <Skeleton className="h-5 w-10 rounded-full" />
+          </div>
+          <Skeleton className="h-4 w-56 mt-2" />
         </div>
-        <Skeleton className="h-8 w-32 rounded-lg" />
+        <Skeleton className="h-9 w-36 rounded-xl" />
       </div>
 
       {/* Filter tabs */}
       <div className="flex gap-2">
         {[1, 2, 3, 4, 5].map((i) => (
-          <Skeleton key={i} className="h-8 w-20 rounded-lg" />
+          <Skeleton key={i} className="h-8 w-24 rounded-full" />
         ))}
       </div>
 
-      {/* Appointment cards */}
-      <div className="space-y-3">
-        {[1, 2, 3, 4, 5].map((i) => (
-          <Card key={i} className="rounded-2xl">
-            <CardContent className="flex items-start justify-between gap-4 py-4">
-              <div className="flex-1 min-w-0 space-y-1.5">
-                <div className="flex items-center gap-2">
-                  <Skeleton className="h-4 w-36" />
-                  <Skeleton className="h-5 w-16 rounded-full" />
+      {/* Date groups */}
+      {[1, 2].map((g) => (
+        <div key={g}>
+          {/* Date header */}
+          <div className="flex items-center gap-3 mb-2">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-4 w-6 rounded-full" />
+            <div className="flex-1 h-px bg-border/40" />
+          </div>
+
+          {/* Rows */}
+          <Card className="divide-y divide-border/40">
+            {Array.from({ length: g === 1 ? 3 : 2 }, (_, i) => (
+              <div key={i} className="flex items-center gap-3 px-4 py-3">
+                <Skeleton className="size-10 rounded-xl shrink-0" />
+                <Skeleton className="size-9 rounded-full shrink-0" />
+                <div className="flex-1 min-w-0 space-y-1.5">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-24" />
                 </div>
-                <Skeleton className="h-4 w-44" />
-                <div className="flex gap-1.5">
-                  <Skeleton className="h-5 w-20 rounded-full" />
-                  <Skeleton className="h-5 w-24 rounded-full" />
-                </div>
+                <Skeleton className="h-5 w-16 rounded-full shrink-0" />
               </div>
-              <Skeleton className="h-8 w-20 rounded-lg shrink-0" />
-            </CardContent>
+            ))}
           </Card>
-        ))}
-      </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/app/(dashboard)/appointments/page.tsx
+++ b/src/app/(dashboard)/appointments/page.tsx
@@ -1,15 +1,79 @@
 import { getAppointments } from "@/server/actions/appointment"
-import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { CalendarDays, ClipboardList } from "lucide-react"
+import { Card } from "@/components/ui/card"
+import {
+  CalendarDays,
+  ClipboardList,
+  Mic,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react"
 import Link from "next/link"
 import { AppointmentsFilter } from "./appointments-filter"
 
-const statusConfig: Record<string, { label: string; className: string }> = {
-  scheduled: { label: "Agendado", className: "bg-vox-primary/10 text-vox-primary border-vox-primary/20" },
-  completed: { label: "Concluido", className: "bg-vox-success/10 text-vox-success border-vox-success/20" },
-  cancelled: { label: "Cancelado", className: "bg-vox-error/10 text-vox-error border-vox-error/20" },
-  no_show: { label: "Faltou", className: "bg-vox-warning/10 text-vox-warning border-vox-warning/20" },
+const statusConfig: Record<string, { label: string; dot: string; className: string }> = {
+  scheduled: { label: "Agendado", dot: "bg-vox-primary", className: "bg-vox-primary/10 text-vox-primary" },
+  completed: { label: "Concluído", dot: "bg-vox-success", className: "bg-vox-success/10 text-vox-success" },
+  cancelled: { label: "Cancelado", dot: "bg-vox-error", className: "bg-vox-error/10 text-vox-error" },
+  no_show: { label: "Faltou", dot: "bg-vox-warning", className: "bg-vox-warning/10 text-vox-warning" },
+}
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleTimeString("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+function formatDateGroupKey(iso: string) {
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  })
+}
+
+function formatDateGroupLabel(iso: string) {
+  const d = new Date(iso)
+  const today = new Date()
+  const tomorrow = new Date()
+  tomorrow.setDate(today.getDate() + 1)
+  const yesterday = new Date()
+  yesterday.setDate(today.getDate() - 1)
+
+  const isSameDay = (a: Date, b: Date) =>
+    a.getDate() === b.getDate() && a.getMonth() === b.getMonth() && a.getFullYear() === b.getFullYear()
+
+  const weekday = d.toLocaleDateString("pt-BR", { weekday: "long" })
+  const dateStr = d.toLocaleDateString("pt-BR", { day: "2-digit", month: "long", year: "numeric" })
+
+  if (isSameDay(d, today)) return `Hoje — ${dateStr}`
+  if (isSameDay(d, tomorrow)) return `Amanhã — ${dateStr}`
+  if (isSameDay(d, yesterday)) return `Ontem — ${dateStr}`
+  return `${weekday.charAt(0).toUpperCase() + weekday.slice(1)} — ${dateStr}`
+}
+
+type Appointment = Awaited<ReturnType<typeof getAppointments>>["appointments"][number]
+
+function groupByDate(appointments: Appointment[]) {
+  const groups: { key: string; label: string; items: Appointment[] }[] = []
+  const map = new Map<string, Appointment[]>()
+
+  for (const apt of appointments) {
+    const key = formatDateGroupKey(apt.date)
+    if (!map.has(key)) map.set(key, [])
+    map.get(key)!.push(apt)
+  }
+
+  for (const [key, items] of map) {
+    groups.push({
+      key,
+      label: formatDateGroupLabel(items[0].date),
+      items,
+    })
+  }
+
+  return groups
 }
 
 export default async function AppointmentsPage({
@@ -22,118 +86,167 @@ export default async function AppointmentsPage({
   const status = params.status ?? "all"
 
   const data = await getAppointments(page, status)
-
-  const formatDate = (iso: string) =>
-    new Date(iso).toLocaleDateString("pt-BR", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    })
+  const groups = groupByDate(data.appointments)
 
   return (
-    <div data-testid="page-appointments" className="space-y-6">
+    <div data-testid="page-appointments" className="space-y-5">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
-          <ClipboardList className="size-5 text-vox-primary" />
-          Atendimentos
-          <span className="text-sm font-normal text-muted-foreground">
-            ({data.total})
-          </span>
-        </h1>
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight flex items-center gap-2.5">
+            Atendimentos
+            <Badge variant="secondary" className="text-[11px] tabular-nums font-semibold">
+              {data.total}
+            </Badge>
+          </h1>
+          <p className="text-[13px] text-muted-foreground mt-1">
+            Histórico de consultas e atendimentos
+          </p>
+        </div>
         <Link
           href="/appointments/new"
-          className="inline-flex items-center gap-1.5 rounded-xl bg-vox-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-vox-primary/90 transition-colors active:scale-[0.98]"
+          aria-label="Nova Consulta"
+          className="inline-flex items-center gap-2 rounded-xl bg-vox-primary px-4 py-2 text-sm font-semibold text-white shadow-md shadow-vox-primary/20 transition-all hover:bg-vox-primary/90 hover:shadow-lg hover:-translate-y-px active:translate-y-0 active:shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2"
         >
-          <CalendarDays className="size-3.5" />
+          <Mic className="size-4" />
           Nova Consulta
         </Link>
       </div>
 
+      {/* Filters */}
       <AppointmentsFilter currentStatus={status} />
 
+      {/* List */}
       {data.appointments.length === 0 ? (
-        <div data-testid="empty-appointments" className="text-center py-16 text-muted-foreground">
-          <ClipboardList className="size-10 mx-auto mb-3 opacity-40" />
-          <p className="text-sm">Nenhum atendimento encontrado.</p>
+        <div data-testid="empty-appointments" className="text-center py-16">
+          <div className="mx-auto mb-3 flex size-14 items-center justify-center rounded-2xl bg-muted/50">
+            <ClipboardList className="size-6 text-muted-foreground/40" />
+          </div>
+          <p className="text-sm font-medium text-muted-foreground">
+            Nenhum atendimento encontrado
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {status !== "all" ? "Tente alterar o filtro de status" : "Registre sua primeira consulta"}
+          </p>
         </div>
       ) : (
-        <div data-testid="appointment-list" className="space-y-3">
-          {data.appointments.map((apt) => {
-            const sc = statusConfig[apt.status] ?? statusConfig.completed
-            return (
-              <Card key={apt.id} data-testid="appointment-item" className="rounded-2xl">
-                <CardContent className="flex items-start justify-between gap-4 py-4">
-                  <div className="flex-1 min-w-0 space-y-1.5">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-sm font-medium">
-                        {formatDate(apt.date)}
-                      </span>
-                      <Badge
-                        variant="outline"
-                        className={sc.className}
-                      >
-                        {sc.label}
-                      </Badge>
-                    </div>
-                    <div>
-                      <Link
-                        href={`/patients/${apt.patient.id}`}
-                        className="text-sm font-medium text-vox-primary hover:underline"
-                      >
-                        {apt.patient.name}
-                      </Link>
-                    </div>
-                    {apt.procedures.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {(apt.procedures as any[]).map((proc, i) => (
-                          <Badge key={i} variant="secondary" className="text-xs">
-                            {typeof proc === "string" ? proc : proc?.name || String(proc)}
+        <div data-testid="appointment-list" className="space-y-4">
+          {groups.map((group) => (
+            <div key={group.key}>
+              {/* Date group header */}
+              <div className="flex items-center gap-3 mb-2">
+                <div className="flex items-center gap-2">
+                  <CalendarDays className="size-3.5 text-muted-foreground" />
+                  <span className="text-[13px] font-semibold text-foreground">
+                    {group.label}
+                  </span>
+                </div>
+                <Badge variant="secondary" className="text-[10px] tabular-nums">
+                  {group.items.length}
+                </Badge>
+                <div className="flex-1 h-px bg-border/40" />
+              </div>
+
+              {/* Appointment rows */}
+              <Card className="divide-y divide-border/40">
+                {group.items.map((apt) => {
+                  const sc = statusConfig[apt.status] ?? statusConfig.completed
+                  return (
+                    <Link
+                      key={apt.id}
+                      href={`/patients/${apt.patient.id}`}
+                      data-testid="appointment-item"
+                      aria-label={`Consulta de ${apt.patient.name} às ${formatTime(apt.date)}`}
+                      className="group flex items-center gap-3 px-4 py-3 first:rounded-t-xl last:rounded-b-xl transition-colors hover:bg-accent cursor-pointer focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-vox-primary/50 outline-none"
+                    >
+                      {/* Time */}
+                      <div className="flex size-10 items-center justify-center rounded-xl bg-vox-primary/[0.08] text-[12px] font-bold text-vox-primary tabular-nums shrink-0">
+                        {formatTime(apt.date)}
+                      </div>
+
+                      {/* Avatar initial */}
+                      <div className="flex size-9 items-center justify-center rounded-full bg-vox-primary/[0.08] text-[13px] font-bold text-vox-primary shrink-0">
+                        {apt.patient.name.charAt(0)}
+                      </div>
+
+                      {/* Content */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-[13px] font-semibold truncate group-hover:text-vox-primary transition-colors">
+                            {apt.patient.name}
+                          </span>
+                        </div>
+                        {apt.procedures.length > 0 && (
+                          <p className="text-[11px] text-muted-foreground truncate mt-0.5">
+                            {(apt.procedures as any[]).map((p) => typeof p === "string" ? p : p?.name || String(p)).join(", ")}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Procedures badges (desktop) */}
+                      <div className="hidden lg:flex gap-1.5 shrink-0">
+                        {(apt.procedures as any[]).slice(0, 2).map((proc, i) => (
+                          <Badge key={i} variant="secondary" className="text-[10px] font-medium">
+                            {typeof proc === "string" ? proc : (proc as any)?.name || String(proc)}
                           </Badge>
                         ))}
+                        {apt.procedures.length > 2 && (
+                          <Badge variant="secondary" className="text-[10px]">
+                            +{apt.procedures.length - 2}
+                          </Badge>
+                        )}
                       </div>
-                    )}
-                    {apt.notes && (
-                      <p className="text-xs text-muted-foreground line-clamp-2">
-                        {apt.notes}
-                      </p>
-                    )}
-                  </div>
-                </CardContent>
+
+                      {/* Status */}
+                      <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full shrink-0 ${sc.className}`}>
+                        {sc.label}
+                      </span>
+                    </Link>
+                  )
+                })}
               </Card>
-            )
-          })}
+            </div>
+          ))}
         </div>
       )}
 
       {/* Pagination */}
       {data.totalPages > 1 && (
-        <div className="flex items-center justify-center gap-4 pt-2">
+        <div className="flex items-center justify-center gap-2 pt-2">
           {page > 1 ? (
             <Link
               href={`/appointments?page=${page - 1}${status !== "all" ? `&status=${status}` : ""}`}
-              aria-label="Pagina anterior"
-              className="text-sm font-medium text-vox-primary hover:underline rounded focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
+              aria-label="Página anterior"
+              className="inline-flex items-center gap-1 rounded-xl border border-border/50 bg-card px-3 py-1.5 text-sm font-medium transition-all hover:bg-accent hover:border-border/70 active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2"
             >
+              <ChevronLeft className="size-4" />
               Anterior
             </Link>
           ) : (
-            <span className="text-sm text-muted-foreground">Anterior</span>
+            <span className="inline-flex items-center gap-1 rounded-xl border border-border/30 px-3 py-1.5 text-sm text-muted-foreground">
+              <ChevronLeft className="size-4" />
+              Anterior
+            </span>
           )}
-          <span className="text-sm text-muted-foreground">
-            Pagina {page} de {data.totalPages}
+
+          <span className="text-sm text-muted-foreground tabular-nums px-2">
+            {page} / {data.totalPages}
           </span>
+
           {page < data.totalPages ? (
             <Link
               href={`/appointments?page=${page + 1}${status !== "all" ? `&status=${status}` : ""}`}
-              aria-label="Proxima pagina"
-              className="text-sm font-medium text-vox-primary hover:underline rounded focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
+              aria-label="Próxima página"
+              className="inline-flex items-center gap-1 rounded-xl border border-border/50 bg-card px-3 py-1.5 text-sm font-medium transition-all hover:bg-accent hover:border-border/70 active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2"
             >
-              Proximo
+              Próximo
+              <ChevronRight className="size-4" />
             </Link>
           ) : (
-            <span className="text-sm text-muted-foreground">Proximo</span>
+            <span className="inline-flex items-center gap-1 rounded-xl border border-border/30 px-3 py-1.5 text-sm text-muted-foreground">
+              Próximo
+              <ChevronRight className="size-4" />
+            </span>
           )}
         </div>
       )}

--- a/src/app/(dashboard)/calendar/components/month-view.tsx
+++ b/src/app/(dashboard)/calendar/components/month-view.tsx
@@ -6,9 +6,11 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import type { AppointmentItem } from "../types"
 import type { BlockedSlotItem } from "@/server/actions/blocked-slot"
-import { DAY_NAMES, MONTH_NAMES, STATUS_CONFIG, STATUS_DOT, formatTime, isToday, getMonthGrid, getBlockedSlotsForDate, buildDayIndex } from "../helpers"
+import { DAY_NAMES, MONTH_NAMES, STATUS_DOT, formatTime, isToday, getMonthGrid, getBlockedSlotsForDate, buildDayIndex, agendaColorBg } from "../helpers"
 import { AppointmentCard } from "./appointment-card"
 import { BlockedSlotPopover } from "./blocked-slot-popover"
+
+const MAX_VISIBLE_ITEMS = 4
 
 function MonthViewInner({
   year,
@@ -54,74 +56,105 @@ function MonthViewInner({
   return (
     <>
       <Card className="rounded-2xl border border-border/40 overflow-hidden">
+        {/* Day headers */}
         <div className="grid grid-cols-7 border-b border-border/40">
           {DAY_NAMES.map((d) => (
             <div key={d} className="py-2.5 text-center text-[11px] font-medium text-muted-foreground uppercase tracking-wider">{d}</div>
           ))}
         </div>
+
+        {/* Grid cells */}
         <div className="grid grid-cols-7">
           {cells.map((day, i) => {
-            if (day === null) return <div key={`empty-${i}`} className="min-h-[80px] sm:min-h-[100px] border-b border-r border-border/20 bg-muted/20" />
+            if (day === null) return <div key={`empty-${i}`} className="min-h-[80px] sm:min-h-[110px] border-b border-r border-border/20 bg-muted/10" />
+
             const dayDate = new Date(year, month, day)
             const dayAppts = getApptsForDay(day)
             const dayBlocked = getBlockedSlotsForDate(blockedSlots, dayDate)
             const today = isToday(dayDate)
             const isSelected = selectedDay === day
+            const totalItems = dayBlocked.length + dayAppts.length
+
+            const allItems: ({ type: "blocked"; item: typeof dayBlocked[0] } | { type: "appt"; item: typeof dayAppts[0] })[] = [
+              ...dayBlocked.map((s) => ({ type: "blocked" as const, item: s })),
+              ...dayAppts.map((a) => ({ type: "appt" as const, item: a })),
+            ]
+            const visible = allItems.slice(0, MAX_VISIBLE_ITEMS)
+            const remaining = allItems.length - visible.length
+
             return (
               <button
                 key={`day-${day}`}
                 onClick={() => onSelectDay(selectedDay === day ? null : day)}
-                className={`min-h-[80px] sm:min-h-[100px] border-b border-r border-border/20 p-1.5 text-left transition-all hover:bg-muted/40 ${isSelected ? "bg-vox-primary/5 ring-1 ring-vox-primary/30" : ""}`}
+                className={`min-h-[80px] sm:min-h-[110px] border-b border-r border-border/20 p-1.5 text-left transition-all hover:bg-muted/30 cursor-pointer ${isSelected ? "bg-vox-primary/5 ring-1 ring-inset ring-vox-primary/30" : ""}`}
               >
-                <div className={`flex items-center justify-center size-7 rounded-full text-xs font-medium mb-1 ${today ? "bg-vox-primary text-white" : "text-foreground"}`}>
-                  {day}
-                </div>
-                <div className="flex flex-col gap-0.5">
-                  {(() => {
-                    const allItems: ({ type: "blocked"; item: typeof dayBlocked[0] } | { type: "appt"; item: typeof dayAppts[0] })[] = [
-                      ...dayBlocked.map((s) => ({ type: "blocked" as const, item: s })),
-                      ...dayAppts.map((a) => ({ type: "appt" as const, item: a })),
-                    ]
-                    const visible = allItems.slice(0, 3)
-                    const remaining = allItems.length - visible.length
-                    return (
-                      <>
-                        {visible.map((entry, i) =>
-                          entry.type === "blocked" ? (
-                            <div
-                              key={`block-${entry.item.id}-${i}`}
-                              className="hidden sm:flex items-center gap-1 truncate text-[10px] px-1.5 py-0.5 rounded-md bg-muted/60 text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
-                              onClick={(e) => handleBlockedSlotClick(e, entry.item)}
-                            >
-                              <Ban className="size-2.5 shrink-0" />
-                              {entry.item.title}
-                            </div>
-                          ) : (
-                            <div key={entry.item.id} className={`hidden sm:block truncate text-[10px] px-1.5 py-0.5 rounded-md ${STATUS_CONFIG[entry.item.status]?.className ?? "bg-muted"}`}>
-                              {formatTime(entry.item.date)} {entry.item.patient.name.split(" ")[0]}
-                            </div>
-                          )
-                        )}
-                        {remaining > 0 && <span className="hidden sm:block text-[10px] text-muted-foreground px-1.5">+{remaining} mais</span>}
-                      </>
-                    )
-                  })()}
-                  {(dayAppts.length > 0 || dayBlocked.length > 0) && (
-                    <div className="flex gap-0.5 sm:hidden mt-0.5">
-                      {dayBlocked.length > 0 && <div className="size-1.5 rounded-full bg-muted-foreground/40" />}
-                      {dayAppts.slice(0, 3).map((a) => (
-                        <div key={a.id} className={`size-1.5 rounded-full ${STATUS_DOT[a.status] ?? "bg-muted-foreground"}`} />
-                      ))}
-                      {dayAppts.length > 3 && <span className="text-[9px] text-muted-foreground">+{dayAppts.length - 3}</span>}
-                    </div>
+                {/* Day number + count badge */}
+                <div className="flex items-center gap-1 mb-1">
+                  <div className={`flex items-center justify-center size-7 rounded-full text-xs font-semibold ${today ? "bg-vox-primary text-white shadow-sm shadow-vox-primary/25" : "text-foreground"}`}>
+                    {day}
+                  </div>
+                  {dayAppts.length > 0 && (
+                    <span className={`hidden sm:inline-flex text-[9px] font-semibold tabular-nums ${today ? "text-vox-primary" : "text-muted-foreground"}`}>
+                      {dayAppts.length}
+                    </span>
                   )}
                 </div>
+
+                {/* Desktop: appointment pills */}
+                <div className="hidden sm:flex flex-col gap-px">
+                  {visible.map((entry, idx) =>
+                    entry.type === "blocked" ? (
+                      <div
+                        key={`block-${entry.item.id}-${idx}`}
+                        className="flex items-center gap-1 truncate text-[10px] px-1.5 py-[3px] rounded-md bg-muted/60 border border-border/30 text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
+                        onClick={(e) => handleBlockedSlotClick(e, entry.item)}
+                      >
+                        <Ban className="size-2 shrink-0 opacity-60" />
+                        <span className="truncate">{entry.item.title}</span>
+                      </div>
+                    ) : (
+                      <div
+                        key={entry.item.id}
+                        className="truncate text-[10px] px-1.5 py-[3px] rounded-md border-l-2 font-medium"
+                        style={{
+                          borderLeftColor: entry.item.agenda?.color || "#14B8A6",
+                          backgroundColor: agendaColorBg(entry.item.agenda?.color, 0.15),
+                          color: entry.item.agenda?.color || "#14B8A6",
+                        }}
+                      >
+                        <span className="opacity-70 tabular-nums">{formatTime(entry.item.date)}</span>{" "}
+                        {entry.item.patient.name}
+                      </div>
+                    )
+                  )}
+                  {remaining > 0 && (
+                    <span className="text-[10px] font-medium text-vox-primary px-1.5">
+                      +{remaining} mais
+                    </span>
+                  )}
+                </div>
+
+                {/* Mobile: dot indicators */}
+                {totalItems > 0 && (
+                  <div className="flex gap-0.5 sm:hidden mt-0.5 flex-wrap">
+                    {dayBlocked.length > 0 && <div className="size-1.5 rounded-full bg-muted-foreground/40" />}
+                    {dayAppts.slice(0, 4).map((a) => (
+                      <div
+                        key={a.id}
+                        className="size-1.5 rounded-full"
+                        style={{ backgroundColor: a.agenda?.color || "#14B8A6" }}
+                      />
+                    ))}
+                    {dayAppts.length > 4 && <span className="text-[8px] text-muted-foreground leading-none">+{dayAppts.length - 4}</span>}
+                  </div>
+                )}
               </button>
             )
           })}
         </div>
       </Card>
 
+      {/* Selected day detail panel */}
       {selectedDay !== null && (
         <div className="space-y-3">
           <h2 className="text-sm font-semibold text-muted-foreground">{selectedDay} de {MONTH_NAMES[month]} de {year}</h2>

--- a/src/app/(dashboard)/calendar/components/week-view.tsx
+++ b/src/app/(dashboard)/calendar/components/week-view.tsx
@@ -228,30 +228,28 @@ function WeekViewInner({
 
   const calculateMinuteFromPointer = useCallback((event: DragMoveEvent | DragEndEvent) => {
     const { over, activatorEvent, delta } = event
-    if (!over || !gridRef.current) return null
+    if (!over || !gridRef.current || !weekGridRef.current) return null
 
     const droppableId = over.id as string
     const lastDash = droppableId.lastIndexOf("-")
-    const hour = parseInt(droppableId.substring(lastDash + 1), 10)
+    const dateIso = droppableId.substring(0, lastDash)
 
-    const cellElement = gridRef.current.querySelector(`[data-cell-id="${droppableId}"]`)
-    if (!cellElement) return { hour, minute: 0, dateIso: droppableId.substring(0, lastDash) }
-
-    const rect = cellElement.getBoundingClientRect()
+    // Calculate minute from pointer Y relative to the entire grid,
+    // avoiding fragile querySelector that fails for some cell IDs.
     const pointerEvent = activatorEvent as PointerEvent
     const pointerY = pointerEvent.clientY + delta.y
-    const relativeY = pointerY - rect.top
-    const clampedY = Math.max(0, Math.min(relativeY, ROW_HEIGHT - 1))
 
-    const rawMinutes = (clampedY / ROW_HEIGHT) * 60
-    const snappedMinutes = snapToQuarter(rawMinutes)
-    const finalMinutes = Math.min(snappedMinutes, 45)
+    const gridRect = gridRef.current.getBoundingClientRect()
+    const scrollTop = weekGridRef.current.scrollTop
+    const relativeToGrid = pointerY - gridRect.top + scrollTop
 
-    return {
-      hour,
-      minute: finalMinutes,
-      dateIso: droppableId.substring(0, lastDash),
-    }
+    // Each row is ROW_HEIGHT. Compute exact position in minutes from FIRST_HOUR.
+    const totalMinutesFromStart = (relativeToGrid / ROW_HEIGHT) * 60
+    const hour = FIRST_HOUR + Math.floor(totalMinutesFromStart / 60)
+    const rawMinuteInHour = totalMinutesFromStart % 60
+    const minute = Math.min(snapToQuarter(Math.max(0, rawMinuteInHour)), 45)
+
+    return { hour, minute, dateIso }
   }, [])
 
   function handleDragMove(event: DragMoveEvent) {
@@ -262,7 +260,16 @@ function WeekViewInner({
       dropMinuteRef.current = result.minute
       dropHourRef.current = result.hour
       dropDateRef.current = result.dateIso
-      setOverCellId(event.over?.id as string || null)
+      // Use the hour from our calculation (not from over.id) to match the ghost to the correct cell
+      const overId = event.over?.id as string || null
+      if (overId) {
+        // Reconstruct cell ID with the computed hour for consistent ghost positioning
+        const lastDash = overId.lastIndexOf("-")
+        const datePartFromOver = overId.substring(0, lastDash)
+        setOverCellId(`${datePartFromOver}-${result.hour}`)
+      } else {
+        setOverCellId(null)
+      }
     } else {
       setGhostMinute(null)
       setDragOverlayTime(null)
@@ -369,7 +376,7 @@ function WeekViewInner({
                       ghostMinute={overCellId === cellId ? ghostMinute : null}
                       className={`h-[88px] border-b border-l border-border/[0.06] transition-colors hover:bg-muted/20 min-w-0 ${isToday(d) ? "bg-vox-primary/[0.015]" : ""} ${hourBlocked.length > 0 ? "bg-muted/30" : ""}`}
                     >
-                      <div data-cell-id={cellId} className="absolute inset-0 pointer-events-none" />
+                      {/* Cell ID for ghost indicator matching */}
 
                       {/* Blocked slots */}
                       {hourBlocked.length > 0 && hourAppts.length === 0 && (

--- a/src/app/(dashboard)/calendar/components/week-view.tsx
+++ b/src/app/(dashboard)/calendar/components/week-view.tsx
@@ -18,14 +18,15 @@ import { Ban } from "lucide-react"
 import { Card } from "@/components/ui/card"
 import type { AppointmentItem } from "../types"
 import type { BlockedSlotItem } from "@/server/actions/blocked-slot"
-import { HOURS, DAY_NAMES, STATUS_CONFIG, formatTime, isToday, buildAppointmentIndex, getBlockedSlotsForHour, calculateOverlapLayout, agendaColorBg } from "../helpers"
+import { HOURS, DAY_NAMES, formatTime, isToday, getBlockedSlotsForHour, agendaColorBg } from "../helpers"
 import { NowLine } from "./now-line"
 import { AppointmentPopover } from "./appointment-popover"
 import { BlockedSlotPopover } from "./blocked-slot-popover"
 
-const ROW_HEIGHT = 72
+const ROW_HEIGHT = 88
 const SNAP_MINUTES = 15
-const SLOTS_PER_HOUR = 60 / SNAP_MINUTES // 4
+const DEFAULT_DURATION_MIN = 30
+const MIN_CARD_HEIGHT = 22
 
 function snapToQuarter(minutes: number): number {
   return Math.round(minutes / SNAP_MINUTES) * SNAP_MINUTES
@@ -35,6 +36,97 @@ function formatHourMinute(hour: number, minute: number): string {
   return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`
 }
 
+// ─── Overlap calculation for a full day column ───
+
+interface PositionedAppointment {
+  appointment: AppointmentItem
+  startMin: number  // minutes from midnight
+  endMin: number
+  column: number
+  totalColumns: number
+}
+
+function layoutDayAppointments(appointments: AppointmentItem[]): PositionedAppointment[] {
+  if (appointments.length === 0) return []
+
+  const items = appointments.map((a) => {
+    const d = new Date(a.date)
+    const startMin = d.getHours() * 60 + d.getMinutes()
+    return {
+      appointment: a,
+      startMin,
+      endMin: startMin + DEFAULT_DURATION_MIN,
+      column: 0,
+      totalColumns: 1,
+    }
+  }).sort((a, b) => a.startMin - b.startMin || a.appointment.id.localeCompare(b.appointment.id))
+
+  // Greedy column assignment
+  const columns: number[][] = [] // each column tracks end times
+
+  for (const item of items) {
+    let placed = false
+    for (let c = 0; c < columns.length; c++) {
+      const lastEnd = columns[c][columns[c].length - 1]
+      if (item.startMin >= lastEnd) {
+        columns[c].push(item.endMin)
+        item.column = c
+        placed = true
+        break
+      }
+    }
+    if (!placed) {
+      item.column = columns.length
+      columns.push([item.endMin])
+    }
+  }
+
+  // Expand totalColumns for overlapping groups
+  for (let i = 0; i < items.length; i++) {
+    let maxCol = items[i].column
+    for (let j = 0; j < items.length; j++) {
+      if (i === j) continue
+      // Check overlap
+      if (items[i].startMin < items[j].endMin && items[i].endMin > items[j].startMin) {
+        maxCol = Math.max(maxCol, items[j].column)
+      }
+    }
+    items[i].totalColumns = Math.max(items[i].totalColumns, maxCol + 1)
+  }
+
+  // Normalize totalColumns within each overlap group
+  for (let i = 0; i < items.length; i++) {
+    const overlapping = items.filter(
+      (j) => j.startMin < items[i].endMin && j.endMin > items[i].startMin
+    )
+    const groupMax = Math.max(...overlapping.map((x) => x.totalColumns))
+    for (const o of overlapping) o.totalColumns = groupMax
+  }
+
+  return items
+}
+
+// ─── Build per-day index ───
+
+function buildDayColumnIndex(appointments: AppointmentItem[]): Map<string, PositionedAppointment[]> {
+  const byDay = new Map<string, AppointmentItem[]>()
+  for (const a of appointments) {
+    const d = new Date(a.date)
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+    const existing = byDay.get(key)
+    if (existing) existing.push(a)
+    else byDay.set(key, [a])
+  }
+
+  const result = new Map<string, PositionedAppointment[]>()
+  for (const [key, appts] of byDay) {
+    result.set(key, layoutDayAppointments(appts))
+  }
+  return result
+}
+
+// ─── Components ───
+
 function DraggableAppointment({ appointment, children }: { appointment: AppointmentItem; children: React.ReactNode }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: appointment.id,
@@ -42,7 +134,7 @@ function DraggableAppointment({ appointment, children }: { appointment: Appointm
   })
 
   return (
-    <div ref={setNodeRef} {...listeners} {...attributes} className={isDragging ? "opacity-50" : ""}>
+    <div ref={setNodeRef} {...listeners} {...attributes} className={isDragging ? "opacity-30 pointer-events-none" : ""}>
       {children}
     </div>
   )
@@ -59,12 +151,11 @@ function DroppableCell({ id, children, className, ghostMinute }: {
   return (
     <div ref={setNodeRef} className={`relative ${className ?? ""} ${isOver ? "bg-vox-primary/10 ring-1 ring-vox-primary/30" : ""}`}>
       {children}
-      {/* Ghost indicator showing exact drop time */}
       {isOver && ghostMinute !== null && ghostMinute !== undefined && (() => {
         const hour = parseInt(id.substring(id.lastIndexOf("-") + 1), 10)
         return (
           <div
-            className="absolute left-0 right-0 h-[2px] bg-vox-primary pointer-events-none z-20"
+            className="absolute left-0 right-0 h-[2px] bg-vox-primary pointer-events-none z-30"
             style={{ top: `${(ghostMinute / 60) * ROW_HEIGHT}px` }}
           >
             <div className="absolute -left-0.5 -top-[4px] size-[10px] rounded-full bg-vox-primary shadow-sm shadow-vox-primary/40" />
@@ -76,6 +167,13 @@ function DroppableCell({ id, children, className, ghostMinute }: {
       })()}
     </div>
   )
+}
+
+// Status styling
+const STATUS_OPACITY: Record<string, string> = {
+  completed: "opacity-60",
+  cancelled: "opacity-40 line-through",
+  no_show: "opacity-50",
 }
 
 function WeekViewInner({
@@ -113,7 +211,8 @@ function WeekViewInner({
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
   )
 
-  const appointmentIndex = useMemo(() => buildAppointmentIndex(appointments), [appointments])
+  // Build positioned appointments per day
+  const dayColumnIndex = useMemo(() => buildDayColumnIndex(appointments), [appointments])
 
   useEffect(() => {
     const container = weekGridRef.current
@@ -127,7 +226,6 @@ function WeekViewInner({
     setActiveDragId(event.active.id as string)
   }
 
-  // Calculate minute precision from pointer position within the cell
   const calculateMinuteFromPointer = useCallback((event: DragMoveEvent | DragEndEvent) => {
     const { over, activatorEvent, delta } = event
     if (!over || !gridRef.current) return null
@@ -136,7 +234,6 @@ function WeekViewInner({
     const lastDash = droppableId.lastIndexOf("-")
     const hour = parseInt(droppableId.substring(lastDash + 1), 10)
 
-    // Find the droppable cell element
     const cellElement = gridRef.current.querySelector(`[data-cell-id="${droppableId}"]`)
     if (!cellElement) return { hour, minute: 0, dateIso: droppableId.substring(0, lastDash) }
 
@@ -148,7 +245,7 @@ function WeekViewInner({
 
     const rawMinutes = (clampedY / ROW_HEIGHT) * 60
     const snappedMinutes = snapToQuarter(rawMinutes)
-    const finalMinutes = Math.min(snappedMinutes, 45) // max :45
+    const finalMinutes = Math.min(snappedMinutes, 45)
 
     return {
       hour,
@@ -184,7 +281,6 @@ function WeekViewInner({
     if (!over || !dragId) return
 
     try {
-      // Use the precise minute from the last drag move
       const result = calculateMinuteFromPointer(event)
       const hour = result?.hour ?? dropHourRef.current
       const minute = result?.minute ?? dropMinuteRef.current
@@ -204,8 +300,9 @@ function WeekViewInner({
     }
   }
 
-  // Track drag overlay time in state for reactive updates
   const [dragOverlayTime, setDragOverlayTime] = useState<string | null>(null)
+
+  const FIRST_HOUR = HOURS[0] // 7
 
   return (
     <DndContext
@@ -216,7 +313,7 @@ function WeekViewInner({
     >
       <Card className="rounded-2xl border border-border/40 overflow-hidden shadow-[0_1px_3px_0_rgb(0_0_0/0.04)]">
         <div ref={weekGridRef} className="overflow-y-auto overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0 max-h-[calc(100vh-220px)]" style={{ scrollbarWidth: "thin", scrollbarColor: "rgba(128,128,128,0.2) transparent" }}>
-          {/* Day headers — must match grid-cols and min-w of time grid exactly */}
+          {/* Day headers */}
           <div className="grid grid-cols-[56px_repeat(7,1fr)] border-b border-border/30 min-w-[700px] bg-muted/20 sticky top-0 z-20 backdrop-blur-sm bg-background/95">
             <div className="py-3" />
             {weekDays.map((d) => {
@@ -226,7 +323,7 @@ function WeekViewInner({
                   key={d.toISOString()}
                   className={`flex flex-col items-center gap-1 py-3 border-l border-border/10 ${today ? "bg-vox-primary/5" : ""}`}
                 >
-                  <span className="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-wider">{DAY_NAMES[d.getDay()]}</span>
+                  <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">{DAY_NAMES[d.getDay()]}</span>
                   <span className={`flex size-8 items-center justify-center rounded-full text-sm font-bold transition-all ${
                     today ? "bg-vox-primary text-white shadow-sm shadow-vox-primary/30" : "text-foreground"
                   }`}>
@@ -247,85 +344,93 @@ function WeekViewInner({
             )}
             {HOURS.map((hour) => (
               <div key={hour} className="contents">
-                <div className="flex items-start justify-end pr-3 pt-2 text-[10px] font-medium text-muted-foreground/60 h-[72px] border-b border-border/[0.06] tabular-nums">
+                {/* Time label */}
+                <div className="flex items-start justify-end pr-3 pt-2 text-[10px] font-medium text-muted-foreground h-[88px] border-b border-border/[0.06] tabular-nums">
                   {String(hour).padStart(2, "0")}:00
                 </div>
+
+                {/* Day cells */}
                 {weekDays.map((d) => {
-                  const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}-${hour}`
-                  const dayAppts = appointmentIndex.get(key) || []
+                  const dayKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
                   const hourBlocked = getBlockedSlotsForHour(blockedSlots, d, hour)
                   const cellId = `${d.toISOString()}-${hour}`
+
+                  // Get positioned appointments that start in this hour
+                  const dayAppts = dayColumnIndex.get(dayKey) || []
+                  const hourAppts = dayAppts.filter((pa) => {
+                    const startHour = Math.floor(pa.startMin / 60)
+                    return startHour === hour
+                  })
+
                   return (
                     <DroppableCell
                       key={cellId}
                       id={cellId}
                       ghostMinute={overCellId === cellId ? ghostMinute : null}
-                      className={`h-[72px] border-b border-l border-border/[0.06] px-1 py-1 transition-colors hover:bg-muted/20 overflow-hidden min-w-0 ${isToday(d) ? "bg-vox-primary/[0.015]" : ""} ${hourBlocked.length > 0 ? "bg-muted/30" : ""}`}
+                      className={`h-[88px] border-b border-l border-border/[0.06] transition-colors hover:bg-muted/20 min-w-0 ${isToday(d) ? "bg-vox-primary/[0.015]" : ""} ${hourBlocked.length > 0 ? "bg-muted/30" : ""}`}
                     >
-                      {/* data attribute for pointer position calculation */}
                       <div data-cell-id={cellId} className="absolute inset-0 pointer-events-none" />
-                      {hourBlocked.length > 0 && dayAppts.length === 0 && (
+
+                      {/* Blocked slots */}
+                      {hourBlocked.length > 0 && hourAppts.length === 0 && (
                         <div
-                          className="relative z-[1] flex items-center gap-1 truncate rounded-lg px-2 py-1.5 text-[10px] font-medium leading-tight bg-muted/40 border-l-[3px] border-muted-foreground/20 text-muted-foreground/70 cursor-pointer hover:bg-muted/60 transition-colors"
+                          className="absolute inset-x-1 top-1 z-[1] flex items-center gap-1 truncate rounded-lg px-2 py-1.5 text-[10px] font-medium leading-tight bg-muted/50 border border-border/30 border-l-[3px] border-l-muted-foreground/30 text-muted-foreground cursor-pointer hover:bg-muted/70 transition-colors"
                           onClick={(e) => {
                             e.stopPropagation()
                             setSelectedBlockedSlot({ slot: hourBlocked[0], position: { top: e.clientY, left: e.clientX } })
                           }}
                         >
-                          <Ban className="size-2.5 shrink-0 opacity-50" />
+                          <Ban className="size-2.5 shrink-0 opacity-60" />
                           {hourBlocked[0].title}
                         </div>
                       )}
-                      {dayAppts.length > 0 && (() => {
-                        const overlapLayout = calculateOverlapLayout(dayAppts)
-                        const hasOverlap = dayAppts.some((a) => {
-                          const pos = overlapLayout.get(a.id)
-                          return pos && pos.totalColumns > 1
-                        })
+
+                      {/* Appointment cards — absolutely positioned by minute */}
+                      {hourAppts.map((pa) => {
+                        const a = pa.appointment
+                        const agendaColor = a.agenda?.color || "#14B8A6"
+                        const minuteInHour = pa.startMin % 60
+                        const topPx = (minuteInHour / 60) * ROW_HEIGHT
+                        const durationMin = pa.endMin - pa.startMin
+                        const heightPx = Math.max(MIN_CARD_HEIGHT, (durationMin / 60) * ROW_HEIGHT - 2)
+                        const widthPct = 100 / pa.totalColumns
+                        const leftPct = pa.column * widthPct
+                        const statusClass = STATUS_OPACITY[a.status] ?? ""
+
                         return (
-                          <div className={`z-[1] ${hasOverlap ? "relative h-[calc(100%-4px)]" : ""}`}>
-                            {dayAppts.map((a) => {
-                              const pos = overlapLayout.get(a.id) || { column: 0, totalColumns: 1 }
-                              const agendaColor = a.agenda?.color || "#14B8A6"
-                              return (
-                                <DraggableAppointment key={a.id} appointment={a}>
-                                  <div
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      setSelectedAppointment({
-                                        appointment: a,
-                                        position: { top: e.clientY, left: e.clientX },
-                                      })
-                                    }}
-                                    className={`rounded-lg px-2 py-1.5 text-[11px] font-medium leading-tight cursor-grab active:cursor-grabbing transition-all hover:shadow-md hover:scale-[1.02] border-l-[3px] backdrop-blur-sm overflow-hidden ${hasOverlap ? "absolute top-0 bottom-0" : ""}`}
-                                    style={{
-                                      borderLeftColor: agendaColor,
-                                      backgroundColor: agendaColorBg(a.agenda?.color, 0.1),
-                                      color: agendaColor,
-                                      ...(hasOverlap
-                                        ? {
-                                            left: `${(pos.column / pos.totalColumns) * 100}%`,
-                                            width: `${(1 / pos.totalColumns) * 100}%`,
-                                          }
-                                        : { marginBottom: "2px" }),
-                                    }}
-                                  >
-                                    <div className="flex items-center gap-1.5">
-                                      <span className="font-bold tabular-nums text-[10px] opacity-70">{formatTime(a.date)}</span>
-                                      <span className="truncate">{a.patient.name}</span>
-                                    </div>
-                                    {a.procedures.length > 0 && (
-                                      <div className="text-[9px] opacity-60 truncate mt-0.5">
-                                        {(a.procedures as any[]).map((p) => typeof p === "string" ? p : p?.name).join(", ")}
-                                      </div>
-                                    )}
-                                  </div>
-                                </DraggableAppointment>
-                              )
-                            })}
-                          </div>
+                          <DraggableAppointment key={a.id} appointment={a}>
+                            <div
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                setSelectedAppointment({
+                                  appointment: a,
+                                  position: { top: e.clientY, left: e.clientX },
+                                })
+                              }}
+                              className={`absolute z-[2] rounded-md px-1.5 py-1 text-[11px] font-medium leading-tight cursor-grab active:cursor-grabbing transition-shadow hover:shadow-md border-l-[3px] overflow-hidden ${statusClass}`}
+                              style={{
+                                top: `${topPx}px`,
+                                height: `${heightPx}px`,
+                                left: `calc(${leftPct}% + 2px)`,
+                                width: `calc(${widthPct}% - 4px)`,
+                                borderLeftColor: agendaColor,
+                                backgroundColor: agendaColorBg(a.agenda?.color, 0.20),
+                                color: agendaColor,
+                              }}
+                            >
+                              <div className="flex items-center gap-1 min-w-0">
+                                <span className="font-bold tabular-nums text-[10px] opacity-80 shrink-0">{formatTime(a.date)}</span>
+                                <span className="truncate">{a.patient.name}</span>
+                              </div>
+                              {heightPx >= 34 && a.procedures.length > 0 && (
+                                <div className="text-[9px] opacity-60 truncate mt-px">
+                                  {(a.procedures as any[]).map((p) => typeof p === "string" ? p : p?.name).join(", ")}
+                                </div>
+                              )}
+                            </div>
+                          </DraggableAppointment>
                         )
-                      })()}
+                      })}
                     </DroppableCell>
                   )
                 })}
@@ -357,7 +462,7 @@ function WeekViewInner({
         />
       )}
 
-      {/* Drag overlay with target time */}
+      {/* Drag overlay */}
       <DragOverlay>
         {activeDragId ? (() => {
           const a = appointments.find((ap) => ap.id === activeDragId)

--- a/src/app/(dashboard)/calendar/components/week-view.tsx
+++ b/src/app/(dashboard)/calendar/components/week-view.tsx
@@ -236,16 +236,18 @@ function WeekViewInner({
 
     // Calculate minute from pointer Y relative to the entire grid,
     // avoiding fragile querySelector that fails for some cell IDs.
+    // Note: getBoundingClientRect() already accounts for scroll position,
+    // so we must NOT add scrollTop (that would double-count the offset).
     const pointerEvent = activatorEvent as PointerEvent
     const pointerY = pointerEvent.clientY + delta.y
 
     const gridRect = gridRef.current.getBoundingClientRect()
-    const scrollTop = weekGridRef.current.scrollTop
-    const relativeToGrid = pointerY - gridRect.top + scrollTop
+    const relativeToGrid = pointerY - gridRect.top
 
     // Each row is ROW_HEIGHT. Compute exact position in minutes from FIRST_HOUR.
-    const totalMinutesFromStart = (relativeToGrid / ROW_HEIGHT) * 60
-    const hour = FIRST_HOUR + Math.floor(totalMinutesFromStart / 60)
+    const totalMinutesFromStart = Math.max(0, (relativeToGrid / ROW_HEIGHT) * 60)
+    const LAST_HOUR = HOURS[HOURS.length - 1]
+    const hour = Math.min(Math.max(FIRST_HOUR, FIRST_HOUR + Math.floor(totalMinutesFromStart / 60)), LAST_HOUR)
     const rawMinuteInHour = totalMinutesFromStart % 60
     const minute = Math.min(snapToQuarter(Math.max(0, rawMinuteInHour)), 45)
 

--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -166,6 +166,8 @@ export default function CalendarPage() {
     }
   }, [])
 
+  const initialLoadDone = useRef(false)
+
   const loadData = useCallback(async (skipCache = false) => {
     const [start, end] = getDateRange()
     const filterIds = selectedAgendaIds.length > 0 ? selectedAgendaIds : undefined
@@ -177,11 +179,16 @@ export default function CalendarPage() {
         setAppointments(cached.appointments)
         setBlockedSlots(cached.blockedSlots)
         setLoading(false)
+        initialLoadDone.current = true
         return
       }
     }
 
-    setLoading(true)
+    // Show loading spinner on initial load or navigation to uncached period
+    // skipCache=true means background refresh (drag/status) — no spinner
+    if (!skipCache) {
+      setLoading(true)
+    }
     try {
       const [apptData, slotData] = await Promise.all([
         getAppointmentsByDateRange(start.toISOString(), end.toISOString(), filterIds),
@@ -195,17 +202,17 @@ export default function CalendarPage() {
       setBlockedSlots([])
     } finally {
       setLoading(false)
+      initialLoadDone.current = true
     }
   }, [getDateRange, selectedAgendaIds])
 
   useEffect(() => { loadAgendas(); loadWaitlistCount(); loadWorkspaceProcedures() }, [loadAgendas, loadWaitlistCount, loadWorkspaceProcedures])
   useEffect(() => { loadData() }, [loadData])
 
-  function reloadData() {
+  /** Background refresh without loading spinner */
+  function refreshInBackground() {
     dataCache.clear()
-    loadAgendas()
     loadData(true)
-    loadWaitlistCount()
   }
 
   // ── Navigation ──
@@ -296,72 +303,125 @@ export default function CalendarPage() {
         toast.success(data.type === "teleconsulta" ? "Teleconsulta agendada" : "Consulta agendada")
       }
       setShowScheduleForm(false)
-      reloadData()
+      // Background refresh — no loading spinner
+      refreshInBackground()
+      loadWaitlistCount()
     } catch (err) {
       toast.error(friendlyError(err, "Erro ao agendar consulta"))
     }
   }
 
   async function handleReschedule(appointmentId: string, newDate: string, forceSchedule = false) {
+    // Optimistic update: move the appointment in local state immediately
+    const previousAppointments = appointments
+    setAppointments((prev) =>
+      prev.map((a) => a.id === appointmentId ? { ...a, date: newDate } : a)
+    )
+
     try {
       const result = await rescheduleAppointment(appointmentId, newDate, forceSchedule)
       if ('error' in result && result.error) {
+        // Revert optimistic update on error
+        setAppointments(previousAppointments)
         if (result.error.startsWith("CONFLICT:")) {
           setConflictMessage(result.error.replace("CONFLICT:", ""))
           conflictResolveRef.current = () => handleReschedule(appointmentId, newDate, true)
         } else { toast.error(result.error) }
         return
       }
-      reloadData()
+      // Background refresh to sync with server (no loading spinner)
+      refreshInBackground()
       toast.success("Consulta reagendada")
     } catch (err) {
+      // Revert optimistic update on failure
+      setAppointments(previousAppointments)
       toast.error(friendlyError(err, "Erro ao reagendar consulta"))
     }
   }
 
   async function handleStatusChange(appointmentId: string, status: string) {
+    // Optimistic update
+    const previousAppointments = appointments
+    setAppointments((prev) =>
+      prev.map((a) => a.id === appointmentId ? { ...a, status } : a)
+    )
+
     try {
       const result = await updateAppointmentStatus(appointmentId, status)
-      if ('error' in result) { toast.error(result.error); return }
-      reloadData()
+      if ('error' in result) {
+        setAppointments(previousAppointments)
+        toast.error(result.error)
+        return
+      }
+      refreshInBackground()
       toast.success("Status atualizado")
     } catch (err) {
+      setAppointments(previousAppointments)
       toast.error(friendlyError(err, "Erro ao atualizar status"))
     }
   }
 
   async function confirmDelete() {
     if (!deleteTarget) return
+    // Optimistic: remove from local state immediately
+    const previousAppointments = appointments
+    const targetId = deleteTarget
+    setAppointments((prev) => prev.filter((a) => a.id !== targetId))
+    setDeleteTarget(null)
+
     try {
-      const result = await deleteAppointment(deleteTarget)
-      if ('error' in result) { toast.error(result.error); return }
-      reloadData()
+      const result = await deleteAppointment(targetId)
+      if ('error' in result) {
+        setAppointments(previousAppointments)
+        toast.error(result.error)
+        return
+      }
+      refreshInBackground()
       toast.success("Consulta excluída")
     } catch (err) {
+      setAppointments(previousAppointments)
       toast.error(friendlyError(err, "Erro ao excluir consulta"))
-    } finally {
-      setDeleteTarget(null)
     }
   }
 
   async function handleDeleteBlockedSlot(id: string) {
+    // Optimistic: remove from local state
+    const previousSlots = blockedSlots
+    setBlockedSlots((prev) => prev.filter((s) => s.id !== id))
+
     try {
       const result = await deleteBlockedSlot(id)
-      if ('error' in result) { toast.error(result.error); return }
-      reloadData()
+      if ('error' in result) {
+        setBlockedSlots(previousSlots)
+        toast.error(result.error)
+        return
+      }
+      refreshInBackground()
       toast.success("Bloqueio removido")
     } catch (err) {
+      setBlockedSlots(previousSlots)
       toast.error(friendlyError(err, "Erro ao remover bloqueio"))
     }
   }
 
   async function handleUpdateBlockedSlot(id: string, data: { title?: string; startDate?: string; endDate?: string; allDay?: boolean; recurring?: string | null }) {
+    // Optimistic: update in local state
+    const previousSlots = blockedSlots
+    setBlockedSlots((prev) =>
+      prev.map((s) => s.id === id ? { ...s, ...data } : s)
+    )
+
     try {
       const result = await updateBlockedSlot(id, data)
-      if ('error' in result) { toast.error(result.error); return }
-      reloadData()
+      if ('error' in result) {
+        setBlockedSlots(previousSlots)
+        toast.error(result.error)
+        return
+      }
+      refreshInBackground()
       toast.success("Bloqueio atualizado")
     } catch (err) {
+      setBlockedSlots(previousSlots)
       toast.error(friendlyError(err, "Erro ao atualizar bloqueio"))
     }
   }
@@ -373,13 +433,13 @@ export default function CalendarPage() {
       {/* ─── Header ─── */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
-          <button onClick={navigatePrev} className="flex size-11 items-center justify-center rounded-xl hover:bg-muted/60 transition-colors text-muted-foreground hover:text-foreground">
+          <button onClick={navigatePrev} aria-label="Período anterior" className="flex size-11 items-center justify-center rounded-xl hover:bg-muted/60 transition-colors text-muted-foreground hover:text-foreground outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50">
             <ChevronLeft className="size-4" />
           </button>
           <h1 className="text-base font-semibold tracking-tight min-w-[200px] text-center">
             {getTitle()}
           </h1>
-          <button onClick={navigateNext} className="flex size-11 items-center justify-center rounded-xl hover:bg-muted/60 transition-colors text-muted-foreground hover:text-foreground">
+          <button onClick={navigateNext} aria-label="Próximo período" className="flex size-11 items-center justify-center rounded-xl hover:bg-muted/60 transition-colors text-muted-foreground hover:text-foreground outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50">
             <ChevronRight className="size-4" />
           </button>
           <Button variant="outline" size="sm" onClick={goToday} className="ml-1 text-[11px] h-7 px-2.5">
@@ -391,15 +451,17 @@ export default function CalendarPage() {
         </div>
 
         <div className="flex items-center gap-2">
-          <div className="flex rounded-xl bg-muted/50 p-0.5">
+          <div className="flex rounded-xl bg-muted/50 p-0.5" role="group" aria-label="Modo de visualização">
             {([
               { key: "day" as const, label: "Dia", icon: Sun },
               { key: "week" as const, label: "Semana", icon: CalendarIcon },
-              { key: "month" as const, label: "Mes", icon: CalendarDays },
+              { key: "month" as const, label: "Mês", icon: CalendarDays },
               { key: "list" as const, label: "Lista", icon: List },
             ] as const).map(({ key, label, icon: Icon }) => (
               <button
                 key={key}
+                aria-pressed={view === key}
+                aria-label={`Visualização por ${label}`}
                 onClick={() => {
                   setView(key)
                   if ((key === "month" || key === "list") && (view === "week" || view === "day")) {
@@ -410,7 +472,7 @@ export default function CalendarPage() {
                     setCurrentDate(new Date(year, month, selectedDay ?? new Date().getDate()))
                   }
                 }}
-                className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-[11px] font-medium transition-all ${
+                className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-[11px] font-medium transition-all outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50 ${
                   view === key ? "bg-background shadow-sm text-foreground" : "text-muted-foreground hover:text-foreground"
                 }`}
               >
@@ -503,7 +565,8 @@ export default function CalendarPage() {
               const result = await createBlockedSlot(data)
               if ('error' in result) { toast.error(result.error); return }
               setShowBlockForm(false)
-              reloadData()
+              dataCache.clear()
+              loadData(true)
               toast.success("Horário bloqueado")
             } catch (err) {
               toast.error(friendlyError(err, "Erro ao bloquear horario"))
@@ -514,7 +577,7 @@ export default function CalendarPage() {
       )}
 
       {/* ─── Loading ─── */}
-      {loading && (
+      {loading && !initialLoadDone.current && (
         <div data-testid="loading-calendar" className="flex flex-col items-center justify-center py-16 gap-3">
           <Loader2 className="size-5 animate-spin text-vox-primary" />
           <p className="text-xs text-muted-foreground">Carregando agenda...</p>
@@ -522,69 +585,82 @@ export default function CalendarPage() {
       )}
 
       {/* ─── Views ─── */}
-      {!loading && view === "week" && (
-        <WeekView
-          weekDays={weekDays}
-          appointments={appointments}
-          blockedSlots={blockedSlots}
-          onReschedule={handleReschedule}
-          onStatusChange={handleStatusChange}
-          onDelete={(id) => setDeleteTarget(id)}
-          onDeleteBlockedSlot={handleDeleteBlockedSlot}
-          onUpdateBlockedSlot={handleUpdateBlockedSlot}
-        />
-      )}
+      {/* Views stay mounted during navigation reloads — only hidden on initial load */}
+      <div className={`relative ${loading && !initialLoadDone.current ? "hidden" : ""}`}>
+        {/* Subtle inline loading indicator for navigation between periods */}
+        {loading && initialLoadDone.current && (
+          <div className="absolute inset-x-0 top-0 z-30 flex justify-center py-2 pointer-events-none">
+            <div className="flex items-center gap-2 rounded-full bg-background/90 backdrop-blur-sm border border-border/50 px-3 py-1.5 shadow-sm">
+              <Loader2 className="size-3 animate-spin text-vox-primary" />
+              <span className="text-[11px] text-muted-foreground font-medium">Atualizando...</span>
+            </div>
+          </div>
+        )}
 
-      {!loading && view === "day" && (
-        <DayView
-          currentDate={currentDate}
-          appointments={appointments}
-          blockedSlots={blockedSlots}
-          onStatusChange={handleStatusChange}
-          onDelete={(id) => setDeleteTarget(id)}
-          onDeleteBlockedSlot={handleDeleteBlockedSlot}
-          onUpdateBlockedSlot={handleUpdateBlockedSlot}
-        />
-      )}
+        {view === "week" && (
+          <WeekView
+            weekDays={weekDays}
+            appointments={appointments}
+            blockedSlots={blockedSlots}
+            onReschedule={handleReschedule}
+            onStatusChange={handleStatusChange}
+            onDelete={(id) => setDeleteTarget(id)}
+            onDeleteBlockedSlot={handleDeleteBlockedSlot}
+            onUpdateBlockedSlot={handleUpdateBlockedSlot}
+          />
+        )}
 
-      {!loading && view === "month" && (
-        <MonthView
-          year={year}
-          month={month}
-          appointments={appointments}
-          blockedSlots={blockedSlots}
-          selectedDay={selectedDay}
-          onSelectDay={setSelectedDay}
-          onStatusChange={handleStatusChange}
-          onDelete={(id) => setDeleteTarget(id)}
-          onDeleteBlockedSlot={handleDeleteBlockedSlot}
-          onUpdateBlockedSlot={handleUpdateBlockedSlot}
-          onScheduleForDay={(day) => {
-            setScheduleDefaultDate(`${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`)
-            setShowScheduleForm(true)
-          }}
-        />
-      )}
+        {view === "day" && (
+          <DayView
+            currentDate={currentDate}
+            appointments={appointments}
+            blockedSlots={blockedSlots}
+            onStatusChange={handleStatusChange}
+            onDelete={(id) => setDeleteTarget(id)}
+            onDeleteBlockedSlot={handleDeleteBlockedSlot}
+            onUpdateBlockedSlot={handleUpdateBlockedSlot}
+          />
+        )}
 
-      {!loading && view === "list" && (
-        <ListView
-          appointments={appointments}
-          onStatusChange={handleStatusChange}
-          onDelete={(id) => setDeleteTarget(id)}
-          onShowSchedule={() => setShowScheduleForm(true)}
-        />
-      )}
+        {view === "month" && (
+          <MonthView
+            year={year}
+            month={month}
+            appointments={appointments}
+            blockedSlots={blockedSlots}
+            selectedDay={selectedDay}
+            onSelectDay={setSelectedDay}
+            onStatusChange={handleStatusChange}
+            onDelete={(id) => setDeleteTarget(id)}
+            onDeleteBlockedSlot={handleDeleteBlockedSlot}
+            onUpdateBlockedSlot={handleUpdateBlockedSlot}
+            onScheduleForDay={(day) => {
+              setScheduleDefaultDate(`${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`)
+              setShowScheduleForm(true)
+            }}
+          />
+        )}
+
+        {view === "list" && (
+          <ListView
+            appointments={appointments}
+            onStatusChange={handleStatusChange}
+            onDelete={(id) => setDeleteTarget(id)}
+            onShowSchedule={() => setShowScheduleForm(true)}
+          />
+        )}
+      </div>
 
       {!loading && appointments.length === 0 && blockedSlots.length === 0 && (
         <div className="flex flex-col items-center gap-2 py-16 text-center">
           <div className="mx-auto mb-1 flex size-14 items-center justify-center rounded-2xl bg-muted/50">
             <CalendarDays className="size-6 text-muted-foreground/40" />
           </div>
-          <p className="text-sm font-medium text-muted-foreground">Sem consultas neste periodo</p>
-          <p className="text-xs text-muted-foreground/70">Agende uma consulta para comecar</p>
+          <p className="text-sm font-medium text-muted-foreground">Sem consultas neste período</p>
+          <p className="text-xs text-muted-foreground/70">Agende uma consulta para começar</p>
           <button
             onClick={() => { setScheduleDefaultDate(""); setShowScheduleForm(true) }}
-            className="inline-flex items-center gap-1.5 mt-2 text-xs font-medium text-vox-primary hover:text-vox-primary/80 rounded-lg px-3 py-1.5 hover:bg-vox-primary/5 transition-colors"
+            className="inline-flex items-center gap-1.5 mt-2 text-xs font-medium text-vox-primary hover:text-vox-primary/80 rounded-lg px-3 py-1.5 hover:bg-vox-primary/5 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2"
           >
             <Plus className="size-3" />
             Agendar consulta

--- a/src/app/(dashboard)/dashboard/loading.tsx
+++ b/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,37 +1,55 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { Card } from "@/components/ui/card"
 
 export default function DashboardLoading() {
   return (
-    <div className="space-y-6">
-      {/* Hero greeting skeleton */}
-      <Skeleton className="h-24 w-full rounded-2xl" />
-
-      {/* Stat cards skeleton */}
-      <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
-        <Skeleton className="h-24 rounded-2xl" />
-        <Skeleton className="h-24 rounded-2xl" />
-        <Skeleton className="h-24 rounded-2xl" />
-        <Skeleton className="h-24 rounded-2xl" />
+    <div className="space-y-4">
+      {/* Hero + inline stats */}
+      <div className="rounded-2xl border border-border/40 p-4 sm:p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-6 w-40" />
+            <Skeleton className="h-3 w-56" />
+          </div>
+          <Skeleton className="h-9 w-32 rounded-xl" />
+        </div>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-16 rounded-xl" />
+          ))}
+        </div>
       </div>
 
-      {/* Quick actions skeleton */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-        <Skeleton className="h-11 rounded-xl" />
-        <Skeleton className="h-11 rounded-xl" />
-        <Skeleton className="h-11 rounded-xl" />
-        <Skeleton className="h-11 rounded-xl" />
+      {/* Today's agenda + quick actions */}
+      <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
+        <Card className="p-4">
+          <div className="flex items-center justify-between mb-3">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton className="h-4 w-11" />
+                <Skeleton className="size-2 rounded-full" />
+                <Skeleton className="h-4 w-32 flex-1" />
+                <Skeleton className="h-5 w-16 rounded-full" />
+              </div>
+            ))}
+          </div>
+        </Card>
+        <div className="flex flex-row lg:flex-col gap-2">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-11 rounded-xl flex-1 lg:flex-none" />
+          ))}
+        </div>
       </div>
 
-      {/* Main content grid skeleton */}
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Skeleton className="h-64 rounded-2xl" />
-        <Skeleton className="h-64 rounded-2xl" />
-      </div>
-
-      {/* Bottom row skeleton */}
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Skeleton className="h-48 rounded-2xl" />
-        <Skeleton className="h-48 rounded-2xl" />
+      {/* Activity + Patients */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Skeleton className="h-56 rounded-2xl" />
+        <Skeleton className="h-56 rounded-2xl" />
       </div>
     </div>
   )

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -5,7 +5,6 @@ import {
   Users,
   CalendarDays,
   Mic,
-  Search,
   Stethoscope,
   TrendingUp,
   TrendingDown,
@@ -13,11 +12,9 @@ import {
   ArrowRight,
   CalendarCheck,
   AudioLines,
-  Sparkles,
   UserPlus,
 } from "lucide-react"
 import Link from "next/link"
-import { QuickSearch } from "./quick-search"
 
 export default async function DashboardPage() {
   const data = await getDashboardData()
@@ -49,7 +46,7 @@ export default async function DashboardPage() {
 
   const statusLabel: Record<string, string> = {
     scheduled: "Agendado",
-    completed: "Concluido",
+    completed: "Concluído",
     cancelled: "Cancelado",
     no_show: "Faltou",
   }
@@ -64,148 +61,109 @@ export default async function DashboardPage() {
   const hour = new Date().getHours()
   const greeting = hour < 12 ? "Bom dia" : hour < 18 ? "Boa tarde" : "Boa noite"
 
+  // Next appointment today
+  const now = new Date()
+  const nextAppointment = data.todayAppointments.find(
+    (a) => new Date(a.date) > now && a.status === "scheduled"
+  )
+
   return (
-    <div data-testid="page-dashboard" className="space-y-6">
-      {/* ─── Hero Greeting ─── */}
-      <div data-tour="hero-card" className="relative overflow-hidden rounded-2xl border border-border/40 bg-gradient-to-br from-vox-primary/[0.05] via-card to-vox-primary/[0.02] p-5 sm:p-6">
-        <div className="pointer-events-none absolute -right-20 -top-20 size-56 rounded-full bg-vox-primary/[0.06] blur-3xl" />
-        <div className="pointer-events-none absolute -left-10 -bottom-10 size-32 rounded-full bg-vox-primary/[0.03] blur-2xl" />
-        <div className="relative flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <div data-testid="page-dashboard" className="space-y-4">
+      {/* ─── Hero + Stats combined ─── */}
+      <div data-tour="hero-card" className="relative overflow-hidden rounded-2xl border border-border/40 bg-gradient-to-br from-vox-primary/[0.05] via-card to-vox-primary/[0.02] p-4 sm:p-5">
+        <div className="pointer-events-none absolute -right-20 -top-20 size-56 rounded-full bg-vox-primary/[0.06] blur-3xl hidden sm:block" />
+
+        {/* Top: greeting + CTA */}
+        <div className="relative flex items-center justify-between gap-4 mb-4">
           <div>
-            <p className="text-[13px] text-muted-foreground font-medium">{greeting}</p>
-            <h1 className="text-xl font-semibold tracking-tight sm:text-2xl mt-0.5">
+            <p className="text-[12px] text-muted-foreground font-medium">{greeting}</p>
+            <h1 className="text-lg font-semibold tracking-tight sm:text-xl">
               {data.clinicName}
             </h1>
+            {nextAppointment && (
+              <p className="text-[12px] text-muted-foreground mt-0.5">
+                Próxima consulta às <span className="font-semibold text-vox-primary">{formatTime(nextAppointment.date)}</span> — {nextAppointment.patient.name}
+              </p>
+            )}
           </div>
           <Link
             href="/appointments/new"
             aria-label="Nova Consulta"
             data-tour="cta-nova-consulta"
-            className="mt-3 sm:mt-0 inline-flex items-center gap-2 rounded-xl bg-vox-primary px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-vox-primary/25 transition-all hover:bg-vox-primary/90 hover:shadow-xl hover:shadow-vox-primary/30 hover:-translate-y-px active:translate-y-0 active:shadow-md focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
+            className="inline-flex items-center gap-2 rounded-xl bg-vox-primary px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-vox-primary/25 transition-all hover:bg-vox-primary/90 hover:shadow-xl hover:-translate-y-px active:translate-y-0 active:shadow-md shrink-0 focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
           >
             <Mic className="size-4" />
-            Nova Consulta
+            <span className="hidden sm:inline">Nova Consulta</span>
+          </Link>
+        </div>
+
+        {/* Inline stats */}
+        <div data-tour="stats-grid" data-testid="section-stats" className="relative grid grid-cols-2 lg:grid-cols-4 gap-2">
+          <Link href="/patients" aria-label={`Pacientes: ${data.totalPatients}`} className="group flex items-center gap-3 rounded-xl bg-background/60 backdrop-blur-sm px-3 py-2.5 border border-border/30 transition-all hover:border-border/50 hover:shadow-sm cursor-pointer">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-vox-primary/[0.08] transition-colors group-hover:bg-vox-primary/[0.12] shrink-0">
+              <Users className="size-4 text-vox-primary" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-[18px] font-bold tabular-nums leading-none tracking-tight">{data.totalPatients}</p>
+              <p className="text-[10px] text-muted-foreground font-medium mt-0.5">Pacientes</p>
+            </div>
+          </Link>
+
+          <Link href="/appointments" aria-label={`Consultas este mês: ${data.monthlyAppointments}`} className="group flex items-center gap-3 rounded-xl bg-background/60 backdrop-blur-sm px-3 py-2.5 border border-border/30 transition-all hover:border-border/50 hover:shadow-sm cursor-pointer">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-vox-success/[0.08] transition-colors group-hover:bg-vox-success/[0.12] shrink-0">
+              <Stethoscope className="size-4 text-vox-success" />
+            </div>
+            <div className="min-w-0">
+              <div className="flex items-center gap-1.5">
+                <p className="text-[18px] font-bold tabular-nums leading-none tracking-tight">{data.monthlyAppointments}</p>
+                {monthlyTrend !== 0 && (
+                  <span className={`inline-flex items-center gap-0.5 text-[10px] font-semibold ${monthlyTrend > 0 ? "text-vox-success" : "text-vox-error"}`}>
+                    {monthlyTrend > 0 ? <TrendingUp className="size-2.5" /> : <TrendingDown className="size-2.5" />}
+                    {monthlyTrend > 0 ? "+" : ""}{monthlyTrend}%
+                  </span>
+                )}
+              </div>
+              <p className="text-[10px] text-muted-foreground font-medium mt-0.5">Este mês</p>
+            </div>
+          </Link>
+
+          <Link href="/calendar" aria-label={`Consultas agendadas: ${data.scheduledAppointments}`} className="group flex items-center gap-3 rounded-xl bg-background/60 backdrop-blur-sm px-3 py-2.5 border border-border/30 transition-all hover:border-border/50 hover:shadow-sm cursor-pointer">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-vox-warning/[0.08] transition-colors group-hover:bg-vox-warning/[0.12] shrink-0">
+              <CalendarCheck className="size-4 text-vox-warning" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-[18px] font-bold tabular-nums leading-none tracking-tight">{data.scheduledAppointments}</p>
+              <p className="text-[10px] text-muted-foreground font-medium mt-0.5">Agendados</p>
+            </div>
+          </Link>
+
+          <Link href="/appointments" aria-label={`Gravações: ${data.totalRecordings} áudios salvos`} className="group flex items-center gap-3 rounded-xl bg-background/60 backdrop-blur-sm px-3 py-2.5 border border-border/30 transition-all hover:border-border/50 hover:shadow-sm cursor-pointer">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-vox-primary/[0.08] transition-colors group-hover:bg-vox-primary/[0.12] shrink-0">
+              <AudioLines className="size-4 text-vox-primary" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-[18px] font-bold tabular-nums leading-none tracking-tight">{data.totalRecordings}</p>
+              <p className="text-[10px] text-muted-foreground font-medium mt-0.5">Gravações</p>
+            </div>
           </Link>
         </div>
       </div>
 
-      {/* ─── Stat Cards ─── */}
-      <div data-tour="stats-grid" data-testid="section-stats" className="grid gap-3 grid-cols-2 lg:grid-cols-4">
-        <Link href="/patients">
-          <Card className="group relative overflow-hidden transition-shadow hover:shadow-md cursor-pointer">
-            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-vox-primary/[0.04] to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-            <CardContent className="pt-5 pb-4">
-              <div className="flex items-start justify-between">
-                <div>
-                  <p className="text-[11px] font-semibold text-muted-foreground/70 uppercase tracking-wider">Pacientes</p>
-                  <p className="text-[28px] font-bold mt-1 tabular-nums leading-none tracking-tight">{data.totalPatients}</p>
-                </div>
-                <div className="flex size-10 items-center justify-center rounded-xl bg-vox-primary/[0.08] transition-colors group-hover:bg-vox-primary/[0.12]">
-                  <Users className="size-[18px] text-vox-primary" />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/appointments">
-          <Card className="group relative overflow-hidden transition-shadow hover:shadow-md cursor-pointer">
-            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-vox-success/[0.04] to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-            <CardContent className="pt-5 pb-4">
-              <div className="flex items-start justify-between">
-                <div>
-                  <p className="text-[11px] font-semibold text-muted-foreground/70 uppercase tracking-wider">Este mes</p>
-                  <p className="text-[28px] font-bold mt-1 tabular-nums leading-none tracking-tight">{data.monthlyAppointments}</p>
-                  {monthlyTrend !== 0 && (
-                    <div className={`inline-flex items-center gap-1 mt-1.5 text-[11px] font-semibold px-1.5 py-0.5 rounded-md ${monthlyTrend > 0 ? "text-vox-success bg-vox-success/10" : "text-vox-error bg-vox-error/10"}`}>
-                      {monthlyTrend > 0 ? <TrendingUp className="size-3" /> : <TrendingDown className="size-3" />}
-                      {monthlyTrend > 0 ? "+" : ""}{monthlyTrend}%
-                    </div>
-                  )}
-                </div>
-                <div className="flex size-10 items-center justify-center rounded-xl bg-vox-success/[0.08] transition-colors group-hover:bg-vox-success/[0.12]">
-                  <Stethoscope className="size-[18px] text-vox-success" />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/calendar">
-          <Card className="group relative overflow-hidden transition-shadow hover:shadow-md cursor-pointer">
-            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-vox-warning/[0.04] to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-            <CardContent className="pt-5 pb-4">
-              <div className="flex items-start justify-between">
-                <div>
-                  <p className="text-[11px] font-semibold text-muted-foreground/70 uppercase tracking-wider">Agendados</p>
-                  <p className="text-[28px] font-bold mt-1 tabular-nums leading-none tracking-tight">{data.scheduledAppointments}</p>
-                  <p className="text-[11px] text-muted-foreground/60 mt-1">proximas consultas</p>
-                </div>
-                <div className="flex size-10 items-center justify-center rounded-xl bg-vox-warning/[0.08] transition-colors group-hover:bg-vox-warning/[0.12]">
-                  <CalendarCheck className="size-[18px] text-vox-warning" />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/appointments">
-          <Card className="group relative overflow-hidden transition-shadow hover:shadow-md cursor-pointer">
-            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-vox-primary/[0.04] to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-            <CardContent className="pt-5 pb-4">
-              <div className="flex items-start justify-between">
-                <div>
-                  <p className="text-[11px] font-semibold text-muted-foreground/70 uppercase tracking-wider">Gravacoes</p>
-                  <p className="text-[28px] font-bold mt-1 tabular-nums leading-none tracking-tight">{data.totalRecordings}</p>
-                  <p className="text-[11px] text-muted-foreground/60 mt-1">audios salvos</p>
-                </div>
-                <div className="flex size-10 items-center justify-center rounded-xl bg-vox-primary/[0.08] transition-colors group-hover:bg-vox-primary/[0.12]">
-                  <AudioLines className="size-[18px] text-vox-primary" />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </Link>
-      </div>
-
-      {/* ─── Quick Actions Row ─── */}
-      <div data-tour="quick-actions" data-testid="section-quick-actions" className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-        {[
-          { href: "/appointments/new", label: "Nova Consulta", icon: Stethoscope, accent: true },
-          { href: "/patients/new/voice", label: "Cadastro por Voz", icon: Mic },
-          { href: "/patients/new", label: "Novo Paciente", icon: UserPlus },
-          { href: "/calendar", label: "Agendar Consulta", icon: CalendarDays },
-        ].map((action) => (
-          <Link
-            key={action.href}
-            href={action.href}
-            aria-label={action.label}
-            className={`group flex items-center gap-2.5 rounded-xl border px-3 py-2.5 text-[12px] font-medium transition-all active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none ${
-              action.accent
-                ? "border-vox-primary/20 bg-vox-primary/[0.05] text-vox-primary hover:bg-vox-primary/[0.10]"
-                : "border-border/50 bg-card hover:bg-accent hover:border-border/70"
-            }`}
-          >
-            <div className={`flex size-7 items-center justify-center rounded-lg shrink-0 ${
-              action.accent ? "bg-vox-primary/[0.12]" : "bg-muted"
-            }`}>
-              <action.icon className={`size-3.5 ${action.accent ? "text-vox-primary" : "text-muted-foreground"}`} />
-            </div>
-            <span className="truncate">{action.label}</span>
-          </Link>
-        ))}
-      </div>
-
-      {/* ─── Main Content Grid ─── */}
-      <div className="grid gap-6 lg:grid-cols-2">
+      {/* ─── Today's Agenda + Quick Actions side by side ─── */}
+      <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
         {/* Today's Agenda */}
         <Card>
-          <CardHeader className="flex-row items-center justify-between pb-3">
+          <CardHeader className="flex-row items-center justify-between pb-2">
             <CardTitle className="flex items-center gap-2 text-sm">
               <div className="flex size-6 items-center justify-center rounded-lg bg-vox-primary/10">
                 <Clock className="size-3.5 text-vox-primary" />
               </div>
               Agenda de Hoje
+              {data.todayAppointments.length > 0 && (
+                <Badge variant="secondary" className="text-[10px] tabular-nums">
+                  {data.todayAppointments.length}
+                </Badge>
+              )}
             </CardTitle>
             <Link
               href="/calendar"
@@ -217,57 +175,97 @@ export default async function DashboardPage() {
           </CardHeader>
           <CardContent>
             {data.todayAppointments.length === 0 ? (
-              <div data-testid="empty-today-appointments" className="text-center py-8">
-                <div className="mx-auto mb-3 flex size-14 items-center justify-center rounded-2xl bg-muted/50">
-                  <CalendarDays className="size-6 text-muted-foreground/40" />
+              <div data-testid="empty-today-appointments" className="text-center py-6">
+                <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-2xl bg-muted/50">
+                  <CalendarDays className="size-5 text-muted-foreground/40" />
                 </div>
                 <p className="text-sm font-medium text-muted-foreground">
                   Nenhuma consulta para hoje
                 </p>
-                <Link
-                  href="/appointments/new"
-                  aria-label="Registrar consulta"
-                  className="inline-flex items-center gap-1.5 mt-3 text-xs font-medium text-vox-primary hover:text-vox-primary/80 rounded-lg px-3 py-1.5 hover:bg-vox-primary/5 transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
-                >
-                  <Stethoscope className="size-3" />
-                  Registrar consulta
-                </Link>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Sua agenda está livre
+                </p>
               </div>
             ) : (
-              <div data-testid="section-upcoming-appointments" className="space-y-1">
-                {data.todayAppointments.map((apt) => (
-                  <Link
-                    key={apt.id}
-                    href={`/patients/${apt.patient.id}`}
-                    aria-label={`Consulta de ${apt.patient.name} as ${formatTime(apt.date)}`}
-                    className="group flex items-center gap-3 rounded-xl px-3 py-2.5 hover:bg-accent transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
-                  >
-                    <div className="flex size-10 items-center justify-center rounded-xl bg-vox-primary/[0.08] text-[11px] font-bold text-vox-primary tabular-nums shrink-0">
-                      {formatTime(apt.date)}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-[13px] font-semibold truncate group-hover:text-vox-primary transition-colors">
-                        {apt.patient.name}
-                      </p>
-                      {apt.procedures.length > 0 && (
-                        <p className="text-[11px] text-muted-foreground/70 truncate mt-0.5">
-                          {(apt.procedures as any[]).map((p) => typeof p === "string" ? p : p?.name || String(p)).join(", ")}
+              <div data-testid="section-upcoming-appointments" className="divide-y divide-border/30">
+                {data.todayAppointments.map((apt) => {
+                  const isPast = new Date(apt.date) < now
+                  return (
+                    <Link
+                      key={apt.id}
+                      href={`/patients/${apt.patient.id}`}
+                      aria-label={`Consulta de ${apt.patient.name} às ${formatTime(apt.date)}`}
+                      className="group flex items-center gap-3 py-2.5 first:pt-0 last:pb-0 hover:bg-accent -mx-3 px-3 rounded-lg transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
+                    >
+                      {/* Time column */}
+                      <div className={`text-[12px] font-bold tabular-nums shrink-0 w-11 text-center ${isPast ? "text-muted-foreground" : "text-vox-primary"}`}>
+                        {formatTime(apt.date)}
+                      </div>
+
+                      {/* Timeline dot */}
+                      <div className="flex flex-col items-center shrink-0">
+                        <div className={`size-2 rounded-full ${isPast ? "bg-muted-foreground/30" : "bg-vox-primary"}`} />
+                      </div>
+
+                      {/* Content */}
+                      <div className="flex-1 min-w-0">
+                        <p className={`text-[13px] font-semibold truncate transition-colors ${isPast ? "text-muted-foreground" : "group-hover:text-vox-primary"}`}>
+                          {apt.patient.name}
                         </p>
-                      )}
-                    </div>
-                    <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full shrink-0 ${statusColor[apt.status] ?? "bg-muted text-muted-foreground"}`}>
-                      {statusLabel[apt.status] ?? apt.status}
-                    </span>
-                  </Link>
-                ))}
+                        {apt.procedures.length > 0 && (
+                          <p className="text-[11px] text-muted-foreground truncate">
+                            {(apt.procedures as any[]).map((p) => typeof p === "string" ? p : p?.name || String(p)).join(", ")}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Status */}
+                      <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full shrink-0 ${statusColor[apt.status] ?? "bg-muted text-muted-foreground"}`}>
+                        {statusLabel[apt.status] ?? apt.status}
+                      </span>
+                    </Link>
+                  )
+                })}
               </div>
             )}
           </CardContent>
         </Card>
 
+        {/* Quick Actions (sidebar) */}
+        <div data-tour="quick-actions" data-testid="section-quick-actions" className="flex flex-row lg:flex-col gap-2">
+          {[
+            { href: "/appointments/new", label: "Nova Consulta", icon: Stethoscope, accent: true },
+            { href: "/patients/new/voice", label: "Cadastro por Voz", icon: Mic },
+            { href: "/patients/new", label: "Novo Paciente", icon: UserPlus },
+            { href: "/calendar", label: "Agendar Consulta", icon: CalendarDays },
+          ].map((action) => (
+            <Link
+              key={action.href}
+              href={action.href}
+              aria-label={action.label}
+              className={`group flex items-center gap-2.5 rounded-xl border px-3 py-2.5 text-[12px] font-medium transition-all active:scale-[0.98] flex-1 lg:flex-none focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none ${
+                action.accent
+                  ? "border-vox-primary/20 bg-vox-primary/[0.05] text-vox-primary hover:bg-vox-primary/[0.10]"
+                  : "border-border/50 bg-card hover:bg-accent hover:border-border/70"
+              }`}
+            >
+              <div className={`flex size-7 items-center justify-center rounded-lg shrink-0 ${
+                action.accent ? "bg-vox-primary/[0.12]" : "bg-muted"
+              }`}>
+                <action.icon className={`size-3.5 ${action.accent ? "text-vox-primary" : "text-muted-foreground"}`} />
+              </div>
+              <span className="truncate flex-1">{action.label}</span>
+              <ArrowRight className={`size-3 shrink-0 opacity-0 -translate-x-1 transition-all group-hover:opacity-60 group-hover:translate-x-0 hidden lg:block ${action.accent ? "text-vox-primary" : "text-muted-foreground"}`} />
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* ─── Activity + Recent Patients ─── */}
+      <div className="grid gap-4 lg:grid-cols-2">
         {/* Recent Activity */}
         <Card>
-          <CardHeader className="flex-row items-center justify-between pb-3">
+          <CardHeader className="flex-row items-center justify-between pb-2">
             <CardTitle className="flex items-center gap-2 text-sm">
               <div className="flex size-6 items-center justify-center rounded-lg bg-vox-primary/10">
                 <CalendarDays className="size-3.5 text-vox-primary" />
@@ -275,7 +273,7 @@ export default async function DashboardPage() {
               Atividade Recente
             </CardTitle>
             <Link
-              href="/calendar"
+              href="/appointments"
               aria-label="Ver toda atividade recente"
               className="text-xs font-medium text-vox-primary hover:text-vox-primary/80 flex items-center gap-1 rounded-lg px-2 py-1 hover:bg-vox-primary/5 transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
             >
@@ -284,9 +282,9 @@ export default async function DashboardPage() {
           </CardHeader>
           <CardContent>
             {data.recentAppointments.length === 0 ? (
-              <div className="text-center py-8">
-                <div className="mx-auto mb-3 flex size-14 items-center justify-center rounded-2xl bg-muted/50">
-                  <CalendarDays className="size-6 text-muted-foreground/40" />
+              <div className="text-center py-6">
+                <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-2xl bg-muted/50">
+                  <CalendarDays className="size-5 text-muted-foreground/40" />
                 </div>
                 <p className="text-sm font-medium text-muted-foreground">
                   Nenhum atendimento registrado
@@ -294,25 +292,25 @@ export default async function DashboardPage() {
                 <Link
                   href="/appointments/new"
                   aria-label="Registrar primeiro atendimento"
-                  className="inline-flex items-center gap-1.5 mt-3 text-xs font-medium text-vox-primary hover:text-vox-primary/80 rounded-lg px-3 py-1.5 hover:bg-vox-primary/5 transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
+                  className="inline-flex items-center gap-1.5 mt-2 text-xs font-medium text-vox-primary hover:text-vox-primary/80 rounded-lg px-3 py-1.5 hover:bg-vox-primary/5 transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
                 >
                   <Stethoscope className="size-3" />
                   Registrar atendimento
                 </Link>
               </div>
             ) : (
-              <div className="space-y-1">
+              <div className="divide-y divide-border/30">
                 {data.recentAppointments.map((apt) => (
                   <Link
                     key={apt.id}
                     href={`/patients/${apt.patient.id}`}
                     aria-label={`Atendimento de ${apt.patient.name} em ${formatDateShort(apt.date)}`}
-                    className="group flex items-center gap-3 rounded-xl px-3 py-2.5 hover:bg-accent transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
+                    className="group flex items-center gap-3 py-2 first:pt-0 last:pb-0 hover:bg-accent -mx-3 px-3 rounded-lg transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
                   >
-                    <span className="text-[11px] text-muted-foreground/70 w-12 shrink-0 tabular-nums font-medium">
+                    <span className="text-[11px] text-muted-foreground w-11 shrink-0 tabular-nums font-medium">
                       {formatDateShort(apt.date)}
                     </span>
-                    <div className="flex size-8 items-center justify-center rounded-full bg-vox-primary/[0.08] text-[11px] font-bold text-vox-primary shrink-0">
+                    <div className="flex size-7 items-center justify-center rounded-full bg-vox-primary/[0.08] text-[10px] font-bold text-vox-primary shrink-0">
                       {apt.patient.name.charAt(0)}
                     </div>
                     <div className="flex-1 min-w-0">
@@ -343,26 +341,10 @@ export default async function DashboardPage() {
             )}
           </CardContent>
         </Card>
-      </div>
-
-      {/* ─── Bottom Row: Search + Recent Patients ─── */}
-      <div className="grid gap-6 lg:grid-cols-2">
-        {/* Quick Search */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2 text-sm">
-              <Search className="size-4 text-vox-primary" />
-              Busca Rapida
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <QuickSearch />
-          </CardContent>
-        </Card>
 
         {/* Recent Patients */}
         <Card>
-          <CardHeader className="flex-row items-center justify-between pb-3">
+          <CardHeader className="flex-row items-center justify-between pb-2">
             <CardTitle className="flex items-center gap-2 text-sm">
               <div className="flex size-6 items-center justify-center rounded-lg bg-vox-primary/10">
                 <Users className="size-3.5 text-vox-primary" />
@@ -372,45 +354,46 @@ export default async function DashboardPage() {
             <Link
               href="/patients"
               aria-label="Ver todos os pacientes"
-              className="text-xs font-medium text-vox-primary hover:text-vox-primary/80 rounded-lg px-2 py-1 hover:bg-vox-primary/5 transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
+              className="text-xs font-medium text-vox-primary hover:text-vox-primary/80 flex items-center gap-1 rounded-lg px-2 py-1 hover:bg-vox-primary/5 transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
             >
-              Ver todos
+              Ver todos <ArrowRight className="size-3" />
             </Link>
           </CardHeader>
           <CardContent>
             {data.recentPatients.length === 0 ? (
               <div className="text-center py-6">
-                <div className="mx-auto mb-3 flex size-12 items-center justify-center rounded-2xl bg-muted/50">
+                <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-2xl bg-muted/50">
                   <Users className="size-5 text-muted-foreground/40" />
                 </div>
-                <p className="text-sm text-muted-foreground">
-                  Nenhum paciente cadastrado.
+                <p className="text-sm font-medium text-muted-foreground">
+                  Nenhum paciente cadastrado
                 </p>
                 <Link
                   href="/patients/new"
-                  className="inline-flex items-center gap-1.5 mt-3 text-xs font-medium text-vox-primary hover:text-vox-primary/80 rounded-lg px-3 py-1.5 hover:bg-vox-primary/5 transition-colors"
+                  aria-label="Cadastrar paciente"
+                  className="inline-flex items-center gap-1.5 mt-2 text-xs font-medium text-vox-primary hover:text-vox-primary/80 rounded-lg px-3 py-1.5 hover:bg-vox-primary/5 transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
                 >
                   <UserPlus className="size-3" />
                   Cadastrar paciente
                 </Link>
               </div>
             ) : (
-              <ul className="space-y-1">
+              <ul className="divide-y divide-border/30">
                 {data.recentPatients.map((patient) => (
                   <li key={patient.id}>
                     <Link
                       href={`/patients/${patient.id}`}
                       aria-label={`Ver paciente ${patient.name}`}
-                      className="group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm hover:bg-accent transition-colors focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
+                      className="group flex items-center gap-3 py-2 first:pt-0 last:pb-0 hover:bg-accent -mx-3 px-3 rounded-lg text-sm transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-2 outline-none"
                     >
-                      <div className="flex size-8 items-center justify-center rounded-full bg-vox-primary/[0.08] text-[11px] font-bold text-vox-primary shrink-0">
+                      <div className="flex size-7 items-center justify-center rounded-full bg-vox-primary/[0.08] text-[10px] font-bold text-vox-primary shrink-0">
                         {patient.name.charAt(0)}
                       </div>
                       <div className="flex-1 min-w-0">
                         <span className="font-medium truncate block group-hover:text-vox-primary transition-colors text-[13px]">
                           {patient.name}
                         </span>
-                        <span className="text-[10px] text-muted-foreground/60">
+                        <span className="text-[10px] text-muted-foreground">
                           {formatDate(patient.lastAppointment)}
                         </span>
                       </div>

--- a/src/app/(dashboard)/patients/new/voice/page.tsx
+++ b/src/app/(dashboard)/patients/new/voice/page.tsx
@@ -2,7 +2,22 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { Mic, AlertTriangle, UserCheck, RotateCcw, Check, Loader2 } from "lucide-react"
+import Link from "next/link"
+import {
+  Mic,
+  AlertTriangle,
+  UserCheck,
+  RotateCcw,
+  Check,
+  Loader2,
+  ArrowLeft,
+  User,
+  Phone,
+  FileText,
+  Stethoscope,
+  ShieldAlert,
+  Lightbulb,
+} from "lucide-react"
 import { RecordButton } from "@/components/record-button"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -145,23 +160,80 @@ export default function VoicePatientPage() {
   // Recording state
   if (state === "recording") {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 px-4">
-        <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold">Novo Paciente por Voz</h1>
-          <p className="text-muted-foreground max-w-md">
-            Fale os dados do paciente: nome, telefone, CPF, procedimentos desejados e observacoes relevantes.
+      <div className="max-w-2xl mx-auto space-y-6">
+        {/* Back link + title */}
+        <div>
+          <Link
+            href="/patients"
+            className="inline-flex items-center gap-1.5 text-[13px] text-muted-foreground hover:text-foreground transition-colors mb-3"
+          >
+            <ArrowLeft className="size-3.5" />
+            Pacientes
+          </Link>
+          <h1 className="text-xl font-semibold tracking-tight">Novo Paciente por Voz</h1>
+          <p className="text-[13px] text-muted-foreground mt-1">
+            Grave um áudio descrevendo o paciente. A IA extrai os dados automaticamente.
           </p>
         </div>
 
-        <RecordButton onRecordingComplete={handleRecordingComplete} size="lg" />
+        {/* Main recording area */}
+        <Card className="relative overflow-hidden">
+          <div className="pointer-events-none absolute -right-16 -top-16 size-40 rounded-full bg-vox-primary/[0.06] blur-3xl hidden sm:block" />
+          <CardContent className="flex flex-col items-center py-10 relative">
+            <RecordButton onRecordingComplete={handleRecordingComplete} size="lg" />
+            <p className="text-sm text-muted-foreground mt-4">
+              Toque para gravar, toque novamente para parar
+            </p>
+          </CardContent>
+        </Card>
 
-        <div className="text-center text-sm text-muted-foreground max-w-sm space-y-1">
-          <p>Toque para iniciar a gravacao</p>
-          <p>Toque novamente para parar</p>
+        {/* What to say — structured hints */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <Lightbulb className="size-4 text-vox-primary" />
+              O que falar?
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {[
+                { icon: User, label: "Nome completo", example: "Maria da Silva", required: true },
+                { icon: Phone, label: "Telefone", example: "(11) 99999-0000" },
+                { icon: FileText, label: "CPF", example: "123.456.789-00" },
+                { icon: Stethoscope, label: "Procedimentos", example: "Limpeza, clareamento" },
+                { icon: ShieldAlert, label: "Alergias / Alertas", example: "Alergia a penicilina" },
+                { icon: Mic, label: "Observações gerais", example: "Primeira consulta, indicação..." },
+              ].map((item) => (
+                <div key={item.label} className="flex items-start gap-2.5 rounded-xl bg-muted/30 px-3 py-2.5">
+                  <div className="flex size-7 items-center justify-center rounded-lg bg-vox-primary/[0.08] shrink-0 mt-0.5">
+                    <item.icon className="size-3.5 text-vox-primary" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-[12px] font-semibold">
+                      {item.label}
+                      {item.required && <span className="text-vox-primary ml-1">*</span>}
+                    </p>
+                    <p className="text-[11px] text-muted-foreground italic truncate">
+                      &ldquo;{item.example}&rdquo;
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Example phrase */}
+        <div className="rounded-xl bg-vox-primary/[0.04] border border-vox-primary/10 px-4 py-3">
+          <p className="text-[12px] font-semibold text-vox-primary mb-1">Exemplo de fala:</p>
+          <p className="text-[12px] text-muted-foreground italic leading-relaxed">
+            &ldquo;Paciente Maria da Silva, telefone 11 99999-0000, CPF 123.456.789-00. Veio para avaliação e limpeza. Tem alergia a dipirona. É a primeira consulta dela.&rdquo;
+          </p>
         </div>
 
         {error && (
-          <Alert variant="destructive" className="max-w-md">
+          <Alert variant="destructive">
             <AlertTriangle className="size-4" />
             <AlertTitle>Erro</AlertTitle>
             <AlertDescription>{error}</AlertDescription>
@@ -174,19 +246,40 @@ export default function VoicePatientPage() {
   // Processing state
   if (state === "processing") {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 px-4">
-        <Loader2 className="size-12 animate-spin text-vox-primary" />
-        <div className="text-center space-y-2">
-          <h2 className="text-xl font-semibold">Processando audio...</h2>
-          <p className="text-muted-foreground">Transcrevendo e extraindo dados do paciente</p>
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">Processando áudio...</h1>
+          <p className="text-[13px] text-muted-foreground mt-1">Transcrevendo e extraindo dados do paciente</p>
         </div>
-        <div className="w-full max-w-md space-y-3">
-          <Skeleton className="h-4 w-full" />
-          <Skeleton className="h-4 w-3/4" />
-          <Skeleton className="h-4 w-1/2" />
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-10 w-full" />
-        </div>
+
+        <Card>
+          <CardContent className="py-10">
+            <div className="flex flex-col items-center gap-4">
+              <div className="flex size-16 items-center justify-center rounded-2xl bg-vox-primary/10">
+                <Loader2 className="size-7 animate-spin text-vox-primary" />
+              </div>
+              <div className="text-center">
+                <p className="text-sm font-medium">Analisando com IA</p>
+                <p className="text-[12px] text-muted-foreground mt-0.5">Isso pode levar alguns segundos</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Skeleton preview of what's coming */}
+        <Card>
+          <CardHeader className="pb-2">
+            <Skeleton className="h-5 w-32" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Skeleton className="h-10 w-full rounded-xl" />
+              <Skeleton className="h-10 w-full rounded-xl" />
+              <Skeleton className="h-10 w-full rounded-xl" />
+              <Skeleton className="h-10 w-full rounded-xl" />
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -20,6 +20,13 @@ import {
   FileText,
   Percent,
   RotateCcw,
+  Salad,
+  Brain,
+  Scale,
+  Dumbbell,
+  PawPrint,
+  Briefcase,
+  type LucideIcon,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -39,45 +46,49 @@ import { ProcedimentosSection } from "./sections/procedimentos-section"
 import { CamposSection } from "./sections/campos-section"
 
 // Lazy-loaded sections (not immediately visible)
+function SectionSkeleton() {
+  return <Skeleton className="h-48 w-full rounded-2xl" />
+}
+
 const TeamSection = dynamic(
   () => import("./sections/team-section").then((m) => m.TeamSection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const AgendasSection = dynamic(
   () => import("./sections/agendas-section").then((m) => m.AgendasSection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const BookingSection = dynamic(
   () => import("./sections/booking-section").then((m) => m.BookingSection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const MessagingSection = dynamic(
   () => import("./sections/messaging-section").then((m) => m.MessagingSection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const AparenciaSection = dynamic(
   () => import("./sections/aparencia-section").then((m) => m.AparenciaSection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const PlanoSection = dynamic(
   () => import("./sections/plano-section").then((m) => m.PlanoSection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const FiscalTab = dynamic(
   () => import("./fiscal-tab").then((m) => m.FiscalTab),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const FormulariosSection = dynamic(
   () => import("./sections/formularios-section").then((m) => m.FormulariosSection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const ComissoesSection = dynamic(
   () => import("./sections/comissoes-section").then((m) => m.ComissoesSection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 const GatewaySection = dynamic(
   () => import("./sections/gateway-section").then((m) => m.GatewaySection),
-  { ssr: false }
+  { ssr: false, loading: SectionSkeleton }
 )
 
 const professionLabels: Record<string, string> = {
@@ -91,15 +102,15 @@ const professionLabels: Record<string, string> = {
   veterinario: "Veterinário",
 }
 
-const professionIcons: Record<string, string> = {
-  dentista: "🦷",
-  nutricionista: "🥗",
-  esteticista: "✨",
-  medico: "🩺",
-  advogado: "⚖️",
-  psicologo: "🧠",
-  fisioterapeuta: "💪",
-  veterinario: "🐾",
+const professionIcons: Record<string, LucideIcon> = {
+  dentista: Stethoscope,
+  nutricionista: Salad,
+  esteticista: Sparkles,
+  medico: Stethoscope,
+  advogado: Scale,
+  psicologo: Brain,
+  fisioterapeuta: Dumbbell,
+  veterinario: PawPrint,
 }
 
 export default function SettingsPage() {
@@ -139,7 +150,7 @@ export default function SettingsPage() {
         setInitialData(data)
       })
       .catch((err) => {
-        setError(friendlyError(err, "Erro ao carregar configuracoes"))
+        setError(friendlyError(err, "Erro ao carregar configurações"))
       })
       .finally(() => setLoading(false))
   }, [])
@@ -163,10 +174,10 @@ export default function SettingsPage() {
       setSaved(true)
       setInitialData({ clinicName, procedures, customFields })
       setHasChanges(false)
-      toast.success("Configuracoes salvas com sucesso")
+      toast.success("Configurações salvas com sucesso")
       setTimeout(() => setSaved(false), 2000)
     } catch (err) {
-      const msg = friendlyError(err, "Erro ao salvar configuracoes")
+      const msg = friendlyError(err, "Erro ao salvar configurações")
       setError(msg)
       toast.error(msg)
     } finally {
@@ -190,19 +201,19 @@ export default function SettingsPage() {
 
   const settingsNav: SettingsNavGroup[] = [
     {
-      title: "Clinica",
+      title: "Clínica",
       items: [
-        { key: "clinica", label: "Dados da Clinica", icon: Building2 },
+        { key: "clinica", label: "Dados da Clínica", icon: Building2 },
         { key: "procedimentos", label: "Procedimentos", icon: ListChecks },
         { key: "campos", label: "Campos Customizados", icon: FormInput },
-        { key: "aparencia", label: "Aparencia", icon: Palette },
+        { key: "aparencia", label: "Aparência", icon: Palette },
       ],
     },
     {
       title: "Equipe",
       items: [
         { key: "equipe", label: "Membros", icon: Users },
-        { key: "comissoes", label: "Comissoes", icon: Percent },
+        { key: "comissoes", label: "Comissões", icon: Percent },
       ],
     },
     {
@@ -213,10 +224,10 @@ export default function SettingsPage() {
       ],
     },
     {
-      title: "Comunicacao",
+      title: "Comunicação",
       items: [
         { key: "mensagens", label: "Mensagens", icon: MessageSquare },
-        { key: "formularios", label: "Formularios", icon: FileText },
+        { key: "formularios", label: "Formulários", icon: FileText },
       ],
     },
     {
@@ -252,7 +263,7 @@ export default function SettingsPage() {
     )
   }
 
-  const profEmoji = professionIcons[professionType?.toLowerCase()] ?? "💼"
+  const ProfIcon = professionIcons[professionType?.toLowerCase()] ?? Briefcase
   const profLabel = professionLabels[professionType?.toLowerCase()] ?? profession
 
   return (
@@ -266,8 +277,8 @@ export default function SettingsPage() {
         <div className="relative flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
           {/* Avatar */}
           <div className="relative">
-            <div className="flex size-20 items-center justify-center rounded-2xl bg-gradient-to-br from-vox-primary to-vox-primary/70 text-3xl shadow-lg shadow-vox-primary/20 animate-scale-in">
-              {profEmoji}
+            <div className="flex size-20 items-center justify-center rounded-2xl bg-gradient-to-br from-vox-primary to-vox-primary/70 shadow-lg shadow-vox-primary/20 animate-scale-in">
+              <ProfIcon className="size-9 text-white" />
             </div>
             <div className="absolute -bottom-1 -right-1 flex size-7 items-center justify-center rounded-full border-2 border-card bg-vox-success text-white shadow-sm">
               <Check className="size-3.5" strokeWidth={3} />
@@ -285,7 +296,7 @@ export default function SettingsPage() {
               </Badge>
             </div>
             <p className="text-sm text-muted-foreground">
-              Gerencie seu workspace, procedimentos e preferencias
+              Gerencie seu workspace, procedimentos e preferências
             </p>
             <div className="flex items-center gap-4 pt-1">
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground/80">
@@ -450,7 +461,7 @@ export default function SettingsPage() {
             <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-card/95 px-5 py-3 shadow-lg backdrop-blur-xl">
               <div className="flex items-center gap-2">
                 <div className="size-2 rounded-full bg-vox-warning animate-pulse" />
-                <span className="text-sm font-medium">Alteracoes nao salvas</span>
+                <span className="text-sm font-medium">Alterações não salvas</span>
               </div>
               <Button
                 onClick={handleSave}
@@ -466,7 +477,7 @@ export default function SettingsPage() {
                 ) : (
                   <>
                     <Save className="size-3.5" />
-                    Salvar Alteracoes
+                    Salvar Alterações
                   </>
                 )}
               </Button>

--- a/src/components/__tests__/command-palette.test.tsx
+++ b/src/components/__tests__/command-palette.test.tsx
@@ -76,7 +76,7 @@ describe("CommandPalette", () => {
     // Open palette via button click
     await user.click(screen.getByText("Buscar..."))
 
-    const input = screen.getByPlaceholderText("Buscar pacientes, paginas, acoes...")
+    const input = screen.getByPlaceholderText("Buscar pacientes, páginas, ações...")
     expect(input).toBeInTheDocument()
 
     await user.type(input, "test")
@@ -89,11 +89,11 @@ describe("CommandPalette", () => {
 
     await user.click(screen.getByText("Buscar..."))
 
-    expect(screen.getByText("Paginas")).toBeInTheDocument()
+    expect(screen.getByText("Páginas")).toBeInTheDocument()
     expect(screen.getByText("Dashboard")).toBeInTheDocument()
     expect(screen.getByText("Pacientes")).toBeInTheDocument()
     expect(screen.getByText("Agenda")).toBeInTheDocument()
-    expect(screen.getByText("Configuracoes")).toBeInTheDocument()
+    expect(screen.getByText("Configurações")).toBeInTheDocument()
   })
 
   it("action items render when palette is open", async () => {
@@ -102,7 +102,7 @@ describe("CommandPalette", () => {
 
     await user.click(screen.getByText("Buscar..."))
 
-    expect(screen.getByText("Acoes")).toBeInTheDocument()
+    expect(screen.getByText("Ações")).toBeInTheDocument()
     expect(screen.getByText("Nova Consulta")).toBeInTheDocument()
     expect(screen.getByText("Cadastro por Voz")).toBeInTheDocument()
     expect(screen.getByText("Novo Paciente (Manual)")).toBeInTheDocument()
@@ -135,7 +135,7 @@ describe("CommandPalette", () => {
     await user.click(screen.getByText("Buscar..."))
 
     expect(
-      screen.getByText("Digite para buscar pacientes, paginas ou acoes")
+      screen.getByText("Digite para buscar pacientes, páginas ou ações")
     ).toBeInTheDocument()
   })
 
@@ -144,12 +144,12 @@ describe("CommandPalette", () => {
     render(<CommandPalette />)
 
     await user.click(screen.getByText("Buscar..."))
-    const input = screen.getByPlaceholderText("Buscar pacientes, paginas, acoes...")
+    const input = screen.getByPlaceholderText("Buscar pacientes, páginas, ações...")
 
     await user.type(input, "config")
 
-    // Configuracoes should match via keywords
-    expect(screen.getByText("Configuracoes")).toBeInTheDocument()
+    // Configurações should match via keywords
+    expect(screen.getByText("Configurações")).toBeInTheDocument()
     // Dashboard should not match "config"
     expect(screen.queryByText("Dashboard")).not.toBeInTheDocument()
   })

--- a/src/components/__tests__/notification-bell.test.tsx
+++ b/src/components/__tests__/notification-bell.test.tsx
@@ -14,10 +14,18 @@ vi.mock("@/server/actions/notification", () => ({
   markAllAsRead: (...args: any[]) => mockMarkAllAsRead(...args),
 }))
 
-vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, ...props }: any) => (
-    <button {...props}>{children}</button>
-  ),
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children, open }: any) => <div data-open={open}>{children}</div>,
+  PopoverTrigger: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: any) => <div>{children}</div>,
+  SheetContent: ({ children }: any) => <div>{children}</div>,
+  SheetHeader: ({ children }: any) => <div>{children}</div>,
+  SheetTitle: ({ children }: any) => <span>{children}</span>,
+  SheetTrigger: ({ children, ...props }: any) => <button {...props}>{children}</button>,
 }))
 
 import { NotificationBell } from "../notification-bell"
@@ -58,7 +66,9 @@ describe("NotificationBell", () => {
     await act(async () => {
       render(<NotificationBell />)
     })
-    expect(screen.getByLabelText("Notificacoes")).toBeInTheDocument()
+    // Both desktop (Popover) and mobile (Sheet) triggers have aria-label
+    const buttons = screen.getAllByLabelText("Notificações")
+    expect(buttons.length).toBeGreaterThanOrEqual(1)
   })
 
   it("shows unread count badge when notifications exist", async () => {
@@ -69,7 +79,9 @@ describe("NotificationBell", () => {
       render(<NotificationBell />)
     })
 
-    expect(screen.getByText("3")).toBeInTheDocument()
+    // Badge shows in both desktop and mobile triggers
+    const badges = screen.getAllByText("3")
+    expect(badges.length).toBeGreaterThanOrEqual(1)
   })
 
   it("does not show badge when unread count is 0", async () => {
@@ -90,11 +102,11 @@ describe("NotificationBell", () => {
       render(<NotificationBell />)
     })
 
-    expect(screen.getByText("9+")).toBeInTheDocument()
+    const badges = screen.getAllByText("9+")
+    expect(badges.length).toBeGreaterThanOrEqual(1)
   })
 
-  it("dropdown opens on click", async () => {
-    const user = userEvent.setup()
+  it("renders notification list with items", async () => {
     mockGetNotifications.mockResolvedValue(sampleNotifications)
     mockGetUnreadCount.mockResolvedValue(1)
 
@@ -102,15 +114,12 @@ describe("NotificationBell", () => {
       render(<NotificationBell />)
     })
 
-    await user.click(screen.getByLabelText("Notificacoes"))
-
-    expect(screen.getByText("Notificacoes")).toBeInTheDocument()
-    expect(screen.getByText("Consulta em 30min")).toBeInTheDocument()
-    expect(screen.getByText("Atualizacao do sistema")).toBeInTheDocument()
+    // With mocked Popover/Sheet, content is always rendered
+    expect(screen.getAllByText("Consulta em 30min").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText("Atualizacao do sistema").length).toBeGreaterThanOrEqual(1)
   })
 
   it("shows empty state when no notifications", async () => {
-    const user = userEvent.setup()
     mockGetNotifications.mockResolvedValue([])
     mockGetUnreadCount.mockResolvedValue(0)
 
@@ -118,9 +127,8 @@ describe("NotificationBell", () => {
       render(<NotificationBell />)
     })
 
-    await user.click(screen.getByLabelText("Notificacoes"))
-
-    expect(screen.getByText("Nenhuma notificação")).toBeInTheDocument()
+    const emptyTexts = screen.getAllByText("Nenhuma notificação")
+    expect(emptyTexts.length).toBeGreaterThanOrEqual(1)
   })
 
   it("mark all as read button calls markAllAsRead", async () => {
@@ -132,14 +140,13 @@ describe("NotificationBell", () => {
       render(<NotificationBell />)
     })
 
-    await user.click(screen.getByLabelText("Notificacoes"))
-    await user.click(screen.getByText("Marcar tudo como lido"))
+    const markAllButtons = screen.getAllByText("Marcar tudo como lido")
+    await user.click(markAllButtons[0])
 
     expect(mockMarkAllAsRead).toHaveBeenCalled()
   })
 
   it("notification body renders when present", async () => {
-    const user = userEvent.setup()
     mockGetNotifications.mockResolvedValue(sampleNotifications)
     mockGetUnreadCount.mockResolvedValue(1)
 
@@ -147,26 +154,7 @@ describe("NotificationBell", () => {
       render(<NotificationBell />)
     })
 
-    await user.click(screen.getByLabelText("Notificacoes"))
-
-    expect(screen.getByText("Joao Silva - 14:00")).toBeInTheDocument()
-  })
-
-  it("dropdown uses responsive width (not only fixed w-80)", async () => {
-    const user = userEvent.setup()
-    mockGetNotifications.mockResolvedValue(sampleNotifications)
-    mockGetUnreadCount.mockResolvedValue(1)
-
-    await act(async () => {
-      render(<NotificationBell />)
-    })
-
-    await user.click(screen.getByLabelText("Notificacoes"))
-
-    // The dropdown should have responsive width class
-    const dropdown = screen.getByText("Notificacoes").closest(
-      "[class*='w-[calc']"
-    )
-    expect(dropdown).toBeInTheDocument()
+    const bodyTexts = screen.getAllByText("Joao Silva - 14:00")
+    expect(bodyTexts.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -32,9 +32,10 @@ const pages = [
   { id: "dashboard", label: "Dashboard", href: "/dashboard", icon: LayoutDashboard, keywords: "painel inicio home" },
   { id: "patients", label: "Pacientes", href: "/patients", icon: Users, keywords: "lista pacientes" },
   { id: "calendar", label: "Agenda", href: "/calendar", icon: CalendarDays, keywords: "calendario consultas agendamento" },
+  { id: "appointments", label: "Atendimentos", href: "/appointments", icon: CalendarDays, keywords: "atendimentos consultas historico lista" },
   { id: "financial", label: "Financeiro", href: "/financial", icon: DollarSign, keywords: "receita faturamento valor" },
-  { id: "reports", label: "Relatorios", href: "/reports", icon: BarChart3, keywords: "relatorios analytics graficos" },
-  { id: "settings", label: "Configuracoes", href: "/settings", icon: Settings, keywords: "config preferencias workspace" },
+  { id: "reports", label: "Relatórios", href: "/reports", icon: BarChart3, keywords: "relatorios analytics graficos" },
+  { id: "settings", label: "Configurações", href: "/settings", icon: Settings, keywords: "config preferencias workspace" },
   { id: "billing", label: "Plano e Assinatura", href: "/settings/billing", icon: CreditCard, keywords: "plano billing assinatura upgrade stripe pagamento" },
 ]
 
@@ -188,8 +189,8 @@ export function CommandPalette() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder="Buscar pacientes, paginas, acoes..."
-              className="flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground/60"
+              placeholder="Buscar pacientes, páginas, ações..."
+              className="flex-1 bg-transparent text-[13px] outline-none focus-visible:ring-0 placeholder:text-muted-foreground/60"
               autoComplete="off"
               spellCheck={false}
             />
@@ -252,7 +253,7 @@ export function CommandPalette() {
             {showPages && (
               <div className="mb-1">
                 <p className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50">
-                  Paginas
+                  Páginas
                 </p>
                 {filteredPages.map((page) => {
                   itemIndex++
@@ -282,7 +283,7 @@ export function CommandPalette() {
             {showActions && (
               <div>
                 <p className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50">
-                  Acoes
+                  Ações
                 </p>
                 {filteredActions.map((action) => {
                   itemIndex++
@@ -311,7 +312,7 @@ export function CommandPalette() {
             {/* Empty state - no query */}
             {!query && (
               <p className="py-4 text-center text-xs text-muted-foreground/60">
-                Digite para buscar pacientes, paginas ou acoes
+                Digite para buscar pacientes, páginas ou ações
               </p>
             )}
           </div>

--- a/src/components/nav-bottom.tsx
+++ b/src/components/nav-bottom.tsx
@@ -8,6 +8,7 @@ import {
   Users,
   CalendarDays,
   Mic,
+  ClipboardList,
   MessageCircle,
   DollarSign,
   BarChart3,
@@ -33,17 +34,18 @@ type NavItem = {
 }
 
 const primaryNav: NavItem[] = [
-  { href: "/dashboard", label: "Inicio", icon: LayoutDashboard, permission: null, tourId: "nav-bottom-inicio" },
+  { href: "/dashboard", label: "Início", icon: LayoutDashboard, permission: null, tourId: "nav-bottom-inicio" },
   { href: "/patients", label: "Pacientes", icon: Users, permission: "patients.list", tourId: "nav-bottom-pacientes" },
   { href: "/appointments/new", label: "Consulta", icon: Mic, accent: true, permission: "clinical.recordings", tourId: "nav-bottom-nova-consulta" },
   { href: "/calendar", label: "Agenda", icon: CalendarDays, permission: "appointments.view", tourId: "nav-bottom-agenda" },
 ]
 
 const moreNav: NavItem[] = [
+  { href: "/appointments", label: "Atendimentos", icon: ClipboardList, permission: "appointments.view" },
   { href: "/mensagens", label: "Mensagens", icon: MessageCircle, permission: "messaging.view" },
   { href: "/financial", label: "Financeiro", icon: DollarSign, permission: "financial.view" },
-  { href: "/reports", label: "Relatorios", icon: BarChart3, permission: "reports.view" },
-  { href: "/settings", label: "Configuracoes", icon: Settings, permission: "settings.view", tourId: "nav-bottom-config" },
+  { href: "/reports", label: "Relatórios", icon: BarChart3, permission: "reports.view" },
+  { href: "/settings", label: "Configurações", icon: Settings, permission: "settings.view", tourId: "nav-bottom-config" },
 ]
 
 export function NavBottom({ role = "owner" }: { role?: WorkspaceRole }) {
@@ -70,7 +72,7 @@ export function NavBottom({ role = "owner" }: { role?: WorkspaceRole }) {
     <nav
       data-nav-bottom
       data-testid="nav-bottom"
-      aria-label="Navegacao principal"
+      aria-label="Navegação principal"
       className="fixed bottom-0 left-0 w-full border-t border-border/50 bg-background/85 backdrop-blur-2xl z-50 md:hidden"
     >
       <div className="grid pb-[env(safe-area-inset-bottom)]" style={{ gridTemplateColumns: `repeat(${totalCols}, minmax(0, 1fr))` }}>
@@ -116,7 +118,7 @@ export function NavBottom({ role = "owner" }: { role?: WorkspaceRole }) {
         {showMore && (
           <Sheet open={open} onOpenChange={setOpen}>
             <SheetTrigger
-              aria-label="Mais opcoes"
+              aria-label="Mais opções"
               className={`relative flex flex-col items-center justify-center gap-0.5 py-2.5 transition-all duration-200 active:scale-95 ${
                 isMoreActive ? "text-vox-primary" : "text-muted-foreground"
               }`}
@@ -135,7 +137,7 @@ export function NavBottom({ role = "owner" }: { role?: WorkspaceRole }) {
             </SheetTrigger>
             <SheetContent side="bottom" className="rounded-t-2xl px-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
               <SheetHeader className="pb-2">
-                <SheetTitle className="text-left text-base">Mais opcoes</SheetTitle>
+                <SheetTitle className="text-left text-base">Mais opções</SheetTitle>
               </SheetHeader>
               <div className="flex flex-col gap-1">
                 {visibleMoreNav.map((item) => {

--- a/src/components/nav-sidebar.tsx
+++ b/src/components/nav-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Users,
   Mic,
   CalendarDays,
+  ClipboardList,
   MessageCircle,
   DollarSign,
   BarChart3,
@@ -30,10 +31,11 @@ const mainNav: NavItem[] = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard, permission: null, tourId: "nav-dashboard" },
   { href: "/patients", label: "Pacientes", icon: Users, permission: "patients.list", tourId: "nav-pacientes" },
   { href: "/calendar", label: "Agenda", icon: CalendarDays, permission: "appointments.view", tourId: "nav-agenda" },
+  { href: "/appointments", label: "Atendimentos", icon: ClipboardList, permission: "appointments.view", tourId: "nav-atendimentos" },
   { href: "/mensagens", label: "Mensagens", icon: MessageCircle, permission: "messaging.view", tourId: "nav-mensagens" },
   { href: "/financial", label: "Financeiro", icon: DollarSign, permission: "financial.view", tourId: "nav-financeiro" },
-  { href: "/reports", label: "Relatorios", icon: BarChart3, permission: "reports.view", tourId: "nav-relatorios" },
-  { href: "/settings", label: "Configuracoes", icon: Settings, permission: "settings.view", tourId: "nav-configuracoes" },
+  { href: "/reports", label: "Relatórios", icon: BarChart3, permission: "reports.view", tourId: "nav-relatorios" },
+  { href: "/settings", label: "Configurações", icon: Settings, permission: "settings.view", tourId: "nav-configuracoes" },
 ]
 
 const actionNav: NavItem[] = [
@@ -82,7 +84,7 @@ export function NavSidebar({ clinicName, role = "owner" }: { clinicName?: string
   const visibleActionNav = actionNav.filter(isVisible)
 
   return (
-    <aside data-testid="nav-sidebar" aria-label="Navegacao principal" className="hidden md:flex w-56 flex-col border-r border-border/40 bg-sidebar">
+    <aside data-testid="nav-sidebar" aria-label="Navegação principal" className="hidden md:flex w-56 flex-col border-r border-border/40 bg-sidebar overflow-y-auto">
       <nav className="flex flex-col gap-0.5 px-3 pt-5">
         <p className="px-3 pb-2.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50">
           Menu
@@ -93,7 +95,7 @@ export function NavSidebar({ clinicName, role = "owner" }: { clinicName?: string
       {visibleActionNav.length > 0 && (
         <nav className="flex flex-col gap-0.5 px-3 pt-5">
           <p className="px-3 pb-2.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50">
-            Acoes
+            Ações
           </p>
           {visibleActionNav.map(renderLink)}
         </nav>

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,7 +1,19 @@
 "use client"
 
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Bell, Check, CalendarClock, AlertTriangle, Info } from "lucide-react"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
 import {
   getNotifications,
   getUnreadCount,
@@ -34,11 +46,93 @@ const TYPE_COLOR: Record<string, string> = {
   system: "text-muted-foreground",
 }
 
+function formatTime(iso: string) {
+  const d = new Date(iso)
+  const now = new Date()
+  const diffMs = now.getTime() - d.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 1) return "agora"
+  if (diffMin < 60) return `${diffMin}min`
+  const diffHours = Math.floor(diffMin / 60)
+  if (diffHours < 24) return `${diffHours}h`
+  return d.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" })
+}
+
+function NotificationList({
+  notifications,
+  unreadCount,
+  onMarkAsRead,
+  onMarkAllRead,
+}: {
+  notifications: NotificationItem[]
+  unreadCount: number
+  onMarkAsRead: (id: string) => void
+  onMarkAllRead: () => void
+}) {
+  return (
+    <>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border/40">
+        <h3 className="text-sm font-semibold">Notificações</h3>
+        {unreadCount > 0 && (
+          <button
+            onClick={onMarkAllRead}
+            className="text-xs font-medium text-vox-primary hover:text-vox-primary/80 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50 rounded cursor-pointer"
+          >
+            Marcar tudo como lido
+          </button>
+        )}
+      </div>
+
+      {/* List */}
+      <div className="max-h-[320px] overflow-y-auto">
+        {notifications.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-10 text-center">
+            <div className="flex size-12 items-center justify-center rounded-2xl bg-muted/50">
+              <Bell className="size-5 text-muted-foreground/40" />
+            </div>
+            <p className="text-xs text-muted-foreground">Nenhuma notificação</p>
+          </div>
+        ) : (
+          notifications.map((n) => {
+            const Icon = TYPE_ICON[n.type] ?? Bell
+            const color = TYPE_COLOR[n.type] ?? "text-muted-foreground"
+            return (
+              <button
+                key={n.id}
+                onClick={() => !n.read && onMarkAsRead(n.id)}
+                className={`flex w-full items-start gap-3 px-4 py-3 text-left transition-colors border-b border-border/20 last:border-0 cursor-pointer ${
+                  n.read ? "opacity-60" : "bg-vox-primary/[0.02] hover:bg-accent"
+                }`}
+              >
+                <div className={`flex size-8 shrink-0 items-center justify-center rounded-xl bg-muted/50 mt-0.5 ${color}`}>
+                  <Icon className="size-4" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-xs font-medium truncate">{n.title}</p>
+                    {!n.read && <div className="size-2 rounded-full bg-vox-primary shrink-0" />}
+                  </div>
+                  {n.body && (
+                    <p className="text-[11px] text-muted-foreground mt-0.5 truncate">{n.body}</p>
+                  )}
+                </div>
+                <span className="text-[11px] text-muted-foreground shrink-0 mt-0.5">
+                  {formatTime(n.createdAt)}
+                </span>
+              </button>
+            )
+          })
+        )}
+      </div>
+    </>
+  )
+}
+
 export function NotificationBell() {
   const [open, setOpen] = useState(false)
   const [notifications, setNotifications] = useState<NotificationItem[]>([])
   const [unreadCount, setUnreadCount] = useState(0)
-  const dropdownRef = useRef<HTMLDivElement>(null)
 
   const refresh = useCallback(async () => {
     try {
@@ -60,28 +154,6 @@ export function NotificationBell() {
     return () => clearInterval(interval)
   }, [refresh])
 
-  // Close on outside click
-  useEffect(() => {
-    function handleClick(e: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setOpen(false)
-      }
-    }
-    if (open) document.addEventListener("mousedown", handleClick)
-    return () => document.removeEventListener("mousedown", handleClick)
-  }, [open])
-
-  // Close on Escape
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && open) {
-        setOpen(false)
-      }
-    }
-    if (open) document.addEventListener("keydown", handleKeyDown)
-    return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [open])
-
   async function handleMarkAsRead(id: string) {
     await markAsRead(id)
     setNotifications((prev) => prev.map((n) => n.id === id ? { ...n, read: true } : n))
@@ -94,92 +166,56 @@ export function NotificationBell() {
     setUnreadCount(0)
   }
 
-  function formatTime(iso: string) {
-    const d = new Date(iso)
-    const now = new Date()
-    const diffMs = now.getTime() - d.getTime()
-    const diffMin = Math.floor(diffMs / 60000)
-    if (diffMin < 1) return "agora"
-    if (diffMin < 60) return `${diffMin}min`
-    const diffHours = Math.floor(diffMin / 60)
-    if (diffHours < 24) return `${diffHours}h`
-    return d.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" })
+  const triggerButton = (
+    <div className="relative flex size-8 items-center justify-center rounded-xl text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer">
+      <Bell className="size-4" />
+      {unreadCount > 0 && (
+        <span className="absolute -top-1 -right-1 flex size-[18px] items-center justify-center rounded-full bg-vox-primary text-[9px] font-bold text-white ring-2 ring-background">
+          {unreadCount > 9 ? "9+" : unreadCount}
+        </span>
+      )}
+    </div>
+  )
+
+  const listProps = {
+    notifications,
+    unreadCount,
+    onMarkAsRead: handleMarkAsRead,
+    onMarkAllRead: handleMarkAllRead,
   }
 
   return (
-    <div className="relative" ref={dropdownRef}>
-      <button
-        onClick={() => setOpen(!open)}
-        className="relative flex size-8 items-center justify-center rounded-xl text-muted-foreground hover:text-foreground hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50"
-        aria-label="Notificacoes"
-      >
-        <Bell className="size-4" />
-        {unreadCount > 0 && (
-          <span className="absolute -top-1 -right-1 flex size-[18px] items-center justify-center rounded-full bg-vox-primary text-[9px] font-bold text-white ring-2 ring-background">
-            {unreadCount > 9 ? "9+" : unreadCount}
-          </span>
-        )}
-      </button>
+    <>
+      {/* Desktop: Popover */}
+      <div className="hidden sm:block">
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger aria-label="Notificações">
+            {triggerButton}
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            sideOffset={8}
+            className="w-80 p-0 overflow-hidden"
+          >
+            <NotificationList {...listProps} />
+          </PopoverContent>
+        </Popover>
+      </div>
 
-      {open && (
-        <div role="menu" className="absolute right-0 top-full mt-2 w-[calc(100vw-1rem)] sm:w-80 max-w-80 rounded-xl border border-border/60 bg-popover shadow-lg z-50 overflow-hidden animate-fade-in">
-          {/* Header */}
-          <div className="flex items-center justify-between px-4 py-3 border-b border-border/40">
-            <h3 className="text-sm font-semibold">Notificacoes</h3>
-            {unreadCount > 0 && (
-              <button
-                onClick={handleMarkAllRead}
-                className="text-xs font-medium text-vox-primary hover:text-vox-primary/80 transition-colors"
-              >
-                Marcar tudo como lido
-              </button>
-            )}
-          </div>
-
-          {/* List */}
-          <div className="max-h-[320px] overflow-y-auto">
-            {notifications.length === 0 ? (
-              <div className="flex flex-col items-center gap-3 py-10 text-center">
-                <div className="flex size-12 items-center justify-center rounded-2xl bg-muted/50">
-                  <Bell className="size-5 text-muted-foreground/40" />
-                </div>
-                <p className="text-xs text-muted-foreground">Nenhuma notificação</p>
-              </div>
-            ) : (
-              notifications.map((n) => {
-                const Icon = TYPE_ICON[n.type] ?? Bell
-                const color = TYPE_COLOR[n.type] ?? "text-muted-foreground"
-                return (
-                  <button
-                    key={n.id}
-                    role="menuitem"
-                    onClick={() => !n.read && handleMarkAsRead(n.id)}
-                    className={`flex w-full items-start gap-3 px-4 py-3 text-left transition-colors border-b border-border/20 last:border-0 ${
-                      n.read ? "opacity-60" : "bg-vox-primary/[0.02] hover:bg-accent"
-                    }`}
-                  >
-                    <div className={`flex size-8 shrink-0 items-center justify-center rounded-xl bg-muted/50 mt-0.5 ${color}`}>
-                      <Icon className="size-4" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <p className="text-xs font-medium truncate">{n.title}</p>
-                        {!n.read && <div className="size-2 rounded-full bg-vox-primary shrink-0" />}
-                      </div>
-                      {n.body && (
-                        <p className="text-[11px] text-muted-foreground mt-0.5 truncate">{n.body}</p>
-                      )}
-                    </div>
-                    <span className="text-[11px] text-muted-foreground/60 shrink-0 mt-0.5">
-                      {formatTime(n.createdAt)}
-                    </span>
-                  </button>
-                )
-              })
-            )}
-          </div>
-        </div>
-      )}
-    </div>
+      {/* Mobile: Sheet */}
+      <div className="sm:hidden">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger aria-label="Notificações">
+            {triggerButton}
+          </SheetTrigger>
+          <SheetContent side="bottom" className="rounded-t-2xl px-0 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+            <SheetHeader className="px-4 pb-0">
+              <SheetTitle className="sr-only">Notificações</SheetTitle>
+            </SheetHeader>
+            <NotificationList {...listProps} />
+          </SheetContent>
+        </Sheet>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- **Dashboard**: hero compacto com stats inline, próxima consulta, timeline dots na agenda de hoje, quick actions em sidebar
- **Appointments**: lista agrupada por data com avatares, time badges, paginação melhorada, link de navegação adicionado
- **Calendar**: optimistic updates em drag/reschedule/status/delete — sem reload de página, views nunca desmontam
- **Settings**: emojis de profissão → ícones Lucide SVG, skeletons nos lazy-loaded sections
- **Notification bell**: refatorado para Popover (desktop) + Sheet (mobile) com focus trap
- **Voice registration**: tela de gravação redesenhada com grid de hints, exemplo de fala, navegação de volta
- **Acessibilidade**: contraste corrigido, aria-labels, cursor-pointer, sidebar overflow

## Changes

| Área | Antes | Depois |
|------|-------|--------|
| Dashboard stats | 4 cards separados ~120px cada | Mini-stats inline dentro do hero ~50px |
| Calendar drag | Full page reload, view desmonta | Optimistic update instantâneo, background sync |
| Appointments | Cards gigantes sem agrupamento | Lista compacta agrupada por data |
| Notification bell | Dropdown custom sem focus trap | Popover (desktop) + Sheet (mobile) |
| Settings icons | Emojis (🦷🥗🩺) | Lucide SVGs (Stethoscope, Salad, Brain) |
| Voice registration | Tela vazia com mic no centro | Grid de hints + exemplo de fala + back link |

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 427/427 tests passing (33 files)
- [ ] Testar drag-and-drop na agenda (deve ser instantâneo, sem flash de loading)
- [ ] Testar navegação semana anterior/próxima na agenda
- [ ] Verificar notification bell em desktop (Popover) e mobile (Sheet)
- [ ] Verificar página de Atendimentos acessível via sidebar, bottom nav, e Cmd+K
- [ ] Verificar tela de cadastro por voz com hints visíveis


🤖 Generated with [Claude Code](https://claude.com/claude-code)