### PR TITLE
feat: UI/UX round 2 — schedule dialog, patient detail, documents, consultation

### DIFF
--- a/src/app/(dashboard)/appointments/new/page.tsx
+++ b/src/app/(dashboard)/appointments/new/page.tsx
@@ -2,7 +2,21 @@
 
 import { useCallback, useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { Search, Loader2, ChevronRight, Mic, ArrowLeft, Sparkles, Users } from "lucide-react"
+import {
+  Search,
+  Loader2,
+  ChevronRight,
+  Mic,
+  ArrowLeft,
+  Sparkles,
+  Users,
+  Stethoscope,
+  ClipboardList,
+  FileText,
+  AlertTriangle,
+  Lightbulb,
+  Pill,
+} from "lucide-react"
 import { RecordButton } from "@/components/record-button"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -182,52 +196,80 @@ export default function NewAppointmentPage() {
   // Step 2: Recording
   if (step === "recording") {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 px-4">
-        {/* Patient badge */}
-        <div className="flex items-center gap-2 rounded-full border border-border/50 bg-card px-4 py-2 shadow-sm">
-          <div className="flex size-6 items-center justify-center rounded-full bg-vox-primary/10 text-[9px] font-bold text-vox-primary">
-            {selectedPatient ? getInitials(selectedPatient.name) : "?"}
+      <div className="max-w-2xl mx-auto space-y-5">
+        {/* Header with patient + back */}
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => { setSelectedPatient(null); setStep("select-patient") }}
+            className="inline-flex items-center gap-1.5 text-[13px] text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="size-3.5" />
+            Trocar paciente
+          </button>
+          <div className="flex items-center gap-2 rounded-full border border-vox-primary/20 bg-vox-primary/5 px-3 py-1.5">
+            <div className="flex size-6 items-center justify-center rounded-full bg-vox-primary/10 text-[9px] font-bold text-vox-primary">
+              {selectedPatient ? getInitials(selectedPatient.name) : "?"}
+            </div>
+            <span className="text-[13px] font-medium">{selectedPatient?.name}</span>
           </div>
-          <span className="text-sm font-medium">{selectedPatient?.name}</span>
         </div>
 
-        <div className="text-center space-y-2">
-          <h1 className="text-xl font-semibold tracking-tight">Gravar Consulta</h1>
-          <p className="text-sm text-muted-foreground max-w-sm mx-auto">
-            Fale sobre procedimentos, observações clínicas e recomendações.
-            Até 30 minutos de gravacao.
-          </p>
-        </div>
-
-        <RecordButton
-          onRecordingComplete={handleRecordingComplete}
-          maxDuration={1800}
-          size="lg"
-        />
-
-        <div className="flex flex-col items-center gap-1 text-xs text-muted-foreground">
-          <p>Toque para iniciar a gravacao</p>
-          <p>Toque novamente para parar</p>
-        </div>
+        {/* Recording card */}
+        <Card className="relative overflow-hidden">
+          <div className="pointer-events-none absolute -right-16 -top-16 size-40 rounded-full bg-vox-primary/[0.06] blur-3xl hidden sm:block" />
+          <CardContent className="flex flex-col items-center py-8 relative">
+            <h1 className="text-lg font-semibold tracking-tight mb-1">Gravar Consulta</h1>
+            <p className="text-[13px] text-muted-foreground mb-5">
+              Toque para gravar, toque novamente para parar
+            </p>
+            <RecordButton
+              onRecordingComplete={handleRecordingComplete}
+              maxDuration={1800}
+              size="lg"
+            />
+            <p className="text-[11px] text-muted-foreground mt-4">Até 30 minutos de gravação</p>
+          </CardContent>
+        </Card>
 
         {error && (
-          <div className="rounded-xl border border-vox-error/30 bg-vox-error/5 px-4 py-3 text-sm text-vox-error max-w-md text-center">
+          <div className="rounded-xl border border-vox-error/30 bg-vox-error/5 px-4 py-3 text-sm text-vox-error text-center">
             {error}
           </div>
         )}
 
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            setSelectedPatient(null)
-            setStep("select-patient")
-          }}
-          className="mt-2 gap-1.5"
-        >
-          <ArrowLeft className="size-3.5" />
-          Trocar Paciente
-        </Button>
+        {/* What to say — structured hints */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <Lightbulb className="size-4 text-vox-primary" />
+              O que falar durante a consulta?
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {[
+                { icon: Stethoscope, label: "Procedimentos realizados", example: "Fiz limpeza e aplicação de flúor" },
+                { icon: ClipboardList, label: "Observações clínicas", example: "Paciente apresenta gengivite leve" },
+                { icon: Pill, label: "Prescrições / Medicações", example: "Receitei amoxicilina 500mg" },
+                { icon: FileText, label: "Recomendações ao paciente", example: "Orientei escovação 3x ao dia" },
+                { icon: AlertTriangle, label: "Alertas / Alergias", example: "Alergia a dipirona confirmada" },
+                { icon: Mic, label: "Próximos passos", example: "Retorno em 30 dias para avaliação" },
+              ].map((item) => (
+                <div key={item.label} className="flex items-start gap-2.5 rounded-xl bg-muted/30 px-3 py-2.5">
+                  <div className="flex size-7 items-center justify-center rounded-lg bg-vox-primary/[0.08] shrink-0 mt-0.5">
+                    <item.icon className="size-3.5 text-vox-primary" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-[12px] font-semibold">{item.label}</p>
+                    <p className="text-[11px] text-muted-foreground italic truncate">
+                      &ldquo;{item.example}&rdquo;
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }

--- a/src/app/(dashboard)/calendar/components/schedule-form.tsx
+++ b/src/app/(dashboard)/calendar/components/schedule-form.tsx
@@ -1,14 +1,67 @@
 "use client"
 
 import { useState, useEffect, memo } from "react"
-import { X, Search, Loader2, Repeat, Video, Building2 } from "lucide-react"
+import { X, Search, Loader2, Repeat, Video, Building2, CalendarDays, Clock } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { searchPatients } from "@/server/actions/patient"
 import type { AgendaItem, PatientOption } from "../types"
+
+// ─── Time slots grouped by period ───
+
+const TIME_PERIODS = [
+  {
+    label: "Manhã",
+    slots: ["07:00", "07:30", "08:00", "08:30", "09:00", "09:30", "10:00", "10:30", "11:00", "11:30"],
+  },
+  {
+    label: "Tarde",
+    slots: ["12:00", "12:30", "13:00", "13:30", "14:00", "14:30", "15:00", "15:30", "16:00", "16:30", "17:00", "17:30"],
+  },
+  {
+    label: "Noite",
+    slots: ["18:00", "18:30", "19:00", "19:30", "20:00"],
+  },
+]
+
+function getDateShortcuts() {
+  const today = new Date()
+  const tomorrow = new Date(today)
+  tomorrow.setDate(today.getDate() + 1)
+
+  const format = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+
+  const dayName = (d: Date) =>
+    d.toLocaleDateString("pt-BR", { weekday: "short" }).replace(".", "")
+
+  // Next 5 weekdays
+  const days: { label: string; value: string; isToday?: boolean }[] = []
+  const cursor = new Date(today)
+  for (let i = 0; i < 7 && days.length < 5; i++) {
+    const d = new Date(cursor)
+    d.setDate(cursor.getDate() + i)
+    const dow = d.getDay()
+    if (dow === 0) continue // skip Sunday
+    days.push({
+      label: i === 0 ? "Hoje" : i === 1 ? "Amanhã" : `${dayName(d)} ${d.getDate()}`,
+      value: format(d),
+      isToday: i === 0,
+    })
+  }
+  return days
+}
+
+// ─── Component ───
 
 function ScheduleFormInner({
   agendas,
@@ -48,6 +101,8 @@ function ScheduleFormInner({
   const [occurrences, setOccurrences] = useState(4)
   const [price, setPrice] = useState("")
 
+  const dateShortcuts = getDateShortcuts()
+
   // Patient search with debounce
   useEffect(() => {
     if (!patientQuery.trim() || patientQuery.length < 2) { setPatientResults([]); return }
@@ -77,38 +132,57 @@ function ScheduleFormInner({
     })
   }
 
+  const canSubmit = !!selectedPatient && !!scheduleDate && !!scheduleTime
+
+  // Step indicators
+  const step1Done = !!selectedPatient
+  const step2Done = !!scheduleDate && !!scheduleTime
+
   return (
-    <Card className="rounded-2xl border border-border/40 shadow-[0_1px_3px_0_rgb(0_0_0/0.04)] p-5">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-sm font-semibold">Agendar Nova Consulta</h2>
-        <button onClick={onCancel} className="p-1 rounded-lg hover:bg-muted/60 text-muted-foreground">
-          <X className="size-4" />
-        </button>
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-2 sm:col-span-2">
-          <Label className="text-xs">Paciente</Label>
+    <Dialog open onOpenChange={(open) => { if (!open) onCancel() }}>
+      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto" showCloseButton>
+        <DialogHeader>
+          <DialogTitle>Agendar Nova Consulta</DialogTitle>
+          <DialogDescription>Preencha os dados para agendar</DialogDescription>
+        </DialogHeader>
+
+      <div className="space-y-5">
+        {/* ─── Step 1: Patient ─── */}
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <div className={`flex size-5 items-center justify-center rounded-full text-[10px] font-bold ${step1Done ? "bg-vox-primary text-white" : "bg-muted text-muted-foreground"}`}>1</div>
+            <Label className="text-xs font-semibold">Paciente <span className="text-vox-primary">*</span></Label>
+          </div>
           {selectedPatient ? (
-            <div className="flex items-center gap-2 rounded-xl bg-vox-primary/5 border border-vox-primary/20 px-3 py-2">
-              <span className="text-sm font-medium">{selectedPatient.name}</span>
-              <button onClick={() => { setSelectedPatient(null); setPatientQuery("") }} className="ml-auto p-0.5 rounded hover:bg-muted/60">
+            <div className="flex items-center gap-3 rounded-xl bg-vox-primary/5 border border-vox-primary/20 px-3 py-2.5">
+              <div className="flex size-8 items-center justify-center rounded-full bg-vox-primary/10 text-[11px] font-bold text-vox-primary shrink-0">
+                {selectedPatient.name.charAt(0)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <span className="text-sm font-medium block truncate">{selectedPatient.name}</span>
+                {selectedPatient.phone && <span className="text-[11px] text-muted-foreground">{selectedPatient.phone}</span>}
+              </div>
+              <button onClick={() => { setSelectedPatient(null); setPatientQuery("") }} className="p-1 rounded-lg hover:bg-muted/60 transition-colors" aria-label="Remover paciente">
                 <X className="size-3.5 text-muted-foreground" />
               </button>
             </div>
           ) : (
             <div className="relative">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
-              <Input placeholder="Buscar paciente por nome..." aria-label="Buscar paciente por nome" value={patientQuery} onChange={(e) => setPatientQuery(e.target.value)} className="pl-9 rounded-xl text-sm" />
+              <Input placeholder="Buscar paciente por nome..." aria-label="Buscar paciente por nome" value={patientQuery} onChange={(e) => setPatientQuery(e.target.value)} className="pl-9 rounded-xl text-sm" autoFocus />
               {(patientResults.length > 0 || searchingPatients) && (
-                <div className="absolute top-full left-0 right-0 mt-1 bg-background border border-border/60 rounded-xl shadow-lg z-10 overflow-hidden">
+                <div className="absolute top-full left-0 right-0 mt-1 bg-popover border border-border/60 rounded-xl shadow-lg z-10 overflow-hidden max-h-[200px] overflow-y-auto">
                   {searchingPatients ? (
                     <div className="flex items-center gap-2 px-3 py-2.5 text-xs text-muted-foreground"><Loader2 className="size-3.5 animate-spin" />Buscando...</div>
                   ) : (
                     patientResults.map((p) => (
                       <button key={p.id} onClick={() => { setSelectedPatient(p); setPatientQuery(""); setPatientResults([]) }}
-                        className="w-full text-left px-3 py-2.5 hover:bg-muted/60 transition-colors border-b border-border/30 last:border-0">
-                        <div className="text-sm font-medium">{p.name}</div>
-                        {p.phone && <div className="text-[11px] text-muted-foreground">{p.phone}</div>}
+                        className="w-full flex items-center gap-3 text-left px-3 py-2.5 hover:bg-accent transition-colors border-b border-border/20 last:border-0 cursor-pointer">
+                        <div className="flex size-7 items-center justify-center rounded-full bg-vox-primary/10 text-[10px] font-bold text-vox-primary shrink-0">{p.name.charAt(0)}</div>
+                        <div className="min-w-0">
+                          <div className="text-sm font-medium truncate">{p.name}</div>
+                          {p.phone && <div className="text-[11px] text-muted-foreground">{p.phone}</div>}
+                        </div>
                       </button>
                     ))
                   )}
@@ -117,146 +191,224 @@ function ScheduleFormInner({
             </div>
           )}
         </div>
-        {agendas.length > 1 && (
-          <div className="space-y-2 sm:col-span-2">
-            <Label className="text-xs">Agenda</Label>
-            <select
-              value={scheduleAgendaId}
-              onChange={(e) => setScheduleAgendaId(e.target.value)}
-              className="w-full h-10 rounded-xl border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-vox-primary/30"
-            >
-              {agendas.map((a) => (
-                <option key={a.id} value={a.id}>{a.name}</option>
-              ))}
-            </select>
-          </div>
-        )}
-        {/* Tipo: Presencial / Teleconsulta */}
-        <div className="space-y-2 sm:col-span-2">
-          <Label className="text-xs">Tipo de Consulta</Label>
-          <div className="flex rounded-xl bg-muted/50 p-0.5 w-fit">
-            <button
-              type="button"
-              onClick={() => setAppointmentType("presencial")}
-              className={`flex items-center gap-1.5 px-3.5 py-1.5 rounded-xl text-xs font-medium transition-all ${
-                appointmentType === "presencial"
-                  ? "bg-background shadow-sm text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              <Building2 className="size-3.5" />
-              Presencial
-            </button>
-            <button
-              type="button"
-              onClick={() => setAppointmentType("teleconsulta")}
-              className={`flex items-center gap-1.5 px-3.5 py-1.5 rounded-xl text-xs font-medium transition-all ${
-                appointmentType === "teleconsulta"
-                  ? "bg-vox-primary/10 shadow-sm text-vox-primary"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              <Video className="size-3.5" />
-              Teleconsulta
-            </button>
-          </div>
-        </div>
 
-        <div className="space-y-2">
-          <Label className="text-xs">Data</Label>
-          <Input type="date" value={scheduleDate} onChange={(e) => setScheduleDate(e.target.value)} className="rounded-xl text-sm" />
-        </div>
-        <div className="space-y-2">
-          <Label className="text-xs">Horário</Label>
-          <div className="grid grid-cols-5 gap-1 max-h-[120px] overflow-y-auto rounded-xl border border-input p-2">
-            {Array.from({ length: 27 }, (_, i) => {
-              const h = Math.floor(i / 2) + 7
-              const m = i % 2 === 0 ? "00" : "30"
-              if (h > 20) return null
-              const val = `${String(h).padStart(2, "0")}:${m}`
-              return (
+        {/* ─── Step 2: Date & Time ─── */}
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <div className={`flex size-5 items-center justify-center rounded-full text-[10px] font-bold ${step2Done ? "bg-vox-primary text-white" : "bg-muted text-muted-foreground"}`}>2</div>
+            <Label className="text-xs font-semibold">Data e Horário <span className="text-vox-primary">*</span></Label>
+          </div>
+
+          {/* Date: shortcuts + input */}
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5 flex-wrap">
+              {dateShortcuts.map((d) => (
                 <button
-                  key={val}
+                  key={d.value}
                   type="button"
-                  onClick={() => setScheduleTime(val)}
-                  className={`py-1.5 rounded-lg text-xs font-medium transition-all ${
-                    scheduleTime === val
+                  onClick={() => setScheduleDate(d.value)}
+                  className={`px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all ${
+                    scheduleDate === d.value
                       ? "bg-vox-primary text-white shadow-sm"
-                      : "hover:bg-muted/60 text-muted-foreground hover:text-foreground"
+                      : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
                   }`}
                 >
-                  {val}
+                  {d.label}
                 </button>
-              )
-            })}
-          </div>
-        </div>
-        <div className="space-y-2 sm:col-span-2">
-          <Label className="text-xs">Observacoes (opcional)</Label>
-          <Textarea value={scheduleNotes} onChange={(e) => setScheduleNotes(e.target.value)} placeholder="Notas sobre a consulta..." className="rounded-xl text-sm min-h-[80px]" />
-        </div>
-        <div className="space-y-2 sm:col-span-2">
-          <Label className="text-xs text-muted-foreground">Valor (R$) — opcional</Label>
-          <Input
-            type="text"
-            inputMode="decimal"
-            placeholder="0,00"
-            value={price}
-            onChange={(e) => setPrice(e.target.value.replace(/[^\d,]/g, ""))}
-            className="h-9 rounded-xl"
-          />
-        </div>
-
-        {/* Recurring section */}
-        <div className="space-y-3 sm:col-span-2 pt-2 border-t border-border/30">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={recurringEnabled}
-              onChange={(e) => setRecurringEnabled(e.target.checked)}
-              className="rounded border-border accent-vox-primary size-4"
-            />
-            <span className="text-xs font-medium flex items-center gap-1.5">
-              <Repeat className="size-3.5 text-muted-foreground" />
-              Agendar recorrente
-            </span>
-          </label>
-          {recurringEnabled && (
-            <div className="grid gap-3 sm:grid-cols-2 pl-6">
-              <div className="space-y-1.5">
-                <Label className="text-xs">Repetir</Label>
-                <select
-                  value={recurrence}
-                  onChange={(e) => setRecurrence(e.target.value as "weekly" | "biweekly")}
-                  className="w-full h-10 rounded-xl border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-vox-primary/30"
-                >
-                  <option value="weekly">Semanal</option>
-                  <option value="biweekly">Quinzenal</option>
-                </select>
-              </div>
-              <div className="space-y-1.5">
-                <Label className="text-xs">Quantidade (2-52)</Label>
+              ))}
+              <div className="relative ml-auto">
+                <CalendarDays className="absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none" />
                 <Input
-                  type="number"
-                  min={2}
-                  max={52}
-                  value={occurrences}
-                  onChange={(e) => setOccurrences(Math.min(52, Math.max(2, parseInt(e.target.value) || 2)))}
-                  className="rounded-xl text-sm"
+                  type="date"
+                  value={scheduleDate}
+                  onChange={(e) => setScheduleDate(e.target.value)}
+                  className="h-7 rounded-lg text-[11px] pl-7 w-[140px]"
                 />
               </div>
             </div>
-          )}
+          </div>
+
+          {/* Time: grouped by period */}
+          <div className="space-y-2">
+            {TIME_PERIODS.map((period) => (
+              <div key={period.label}>
+                <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-1 flex items-center gap-1.5">
+                  <Clock className="size-2.5" />
+                  {period.label}
+                </p>
+                <div className="flex flex-wrap gap-1">
+                  {period.slots.map((val) => (
+                    <button
+                      key={val}
+                      type="button"
+                      onClick={() => setScheduleTime(val)}
+                      className={`px-2 py-1 rounded-lg text-[11px] font-medium tabular-nums transition-all ${
+                        scheduleTime === val
+                          ? "bg-vox-primary text-white shadow-sm"
+                          : "bg-muted/40 text-muted-foreground hover:bg-muted hover:text-foreground"
+                      }`}
+                    >
+                      {val}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* ─── Step 3: Details (collapsible feel) ─── */}
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <div className="flex size-5 items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground">3</div>
+            <Label className="text-xs font-semibold">Detalhes</Label>
+            <span className="text-[10px] text-muted-foreground">(opcional)</span>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            {/* Agenda selector */}
+            {agendas.length > 1 && (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-[11px] text-muted-foreground">Agenda</Label>
+                <div className="flex flex-wrap gap-1.5">
+                  {agendas.map((a) => (
+                    <button
+                      key={a.id}
+                      type="button"
+                      onClick={() => setScheduleAgendaId(a.id)}
+                      className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px] font-medium border transition-all ${
+                        scheduleAgendaId === a.id
+                          ? "border-border/60 bg-background shadow-sm text-foreground"
+                          : "border-transparent bg-muted/40 text-muted-foreground hover:bg-muted"
+                      }`}
+                    >
+                      <span className="size-2 rounded-full shrink-0" style={{ backgroundColor: a.color }} />
+                      {a.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Type: Presencial / Teleconsulta */}
+            <div className="space-y-1.5">
+              <Label className="text-[11px] text-muted-foreground">Tipo</Label>
+              <div className="flex rounded-xl bg-muted/50 p-0.5 w-fit">
+                <button
+                  type="button"
+                  onClick={() => setAppointmentType("presencial")}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-medium transition-all ${
+                    appointmentType === "presencial"
+                      ? "bg-background shadow-sm text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Building2 className="size-3" />
+                  Presencial
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setAppointmentType("teleconsulta")}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-medium transition-all ${
+                    appointmentType === "teleconsulta"
+                      ? "bg-vox-primary/10 shadow-sm text-vox-primary"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Video className="size-3" />
+                  Teleconsulta
+                </button>
+              </div>
+            </div>
+
+            {/* Price */}
+            <div className="space-y-1.5">
+              <Label className="text-[11px] text-muted-foreground">Valor (R$)</Label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                placeholder="0,00"
+                value={price}
+                onChange={(e) => setPrice(e.target.value.replace(/[^\d,]/g, ""))}
+                className="h-8 rounded-lg text-sm"
+              />
+            </div>
+
+            {/* Notes */}
+            <div className="space-y-1.5 sm:col-span-2">
+              <Label className="text-[11px] text-muted-foreground">Observações</Label>
+              <Textarea value={scheduleNotes} onChange={(e) => setScheduleNotes(e.target.value)} placeholder="Notas sobre a consulta..." className="rounded-xl text-sm min-h-[60px] resize-none" />
+            </div>
+          </div>
+
+          {/* Recurring section */}
+          <div className="pt-2 border-t border-border/30">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={recurringEnabled}
+                onChange={(e) => setRecurringEnabled(e.target.checked)}
+                className="rounded border-border accent-vox-primary size-3.5"
+              />
+              <span className="text-[11px] font-medium flex items-center gap-1.5">
+                <Repeat className="size-3 text-muted-foreground" />
+                Agendar recorrente
+              </span>
+            </label>
+            {recurringEnabled && (
+              <div className="grid gap-3 sm:grid-cols-2 mt-3 pl-5">
+                <div className="space-y-1.5">
+                  <Label className="text-[11px] text-muted-foreground">Repetir</Label>
+                  <div className="flex rounded-lg bg-muted/50 p-0.5 w-fit">
+                    <button type="button" onClick={() => setRecurrence("weekly")}
+                      className={`px-3 py-1 rounded-md text-[11px] font-medium transition-all ${recurrence === "weekly" ? "bg-background shadow-sm text-foreground" : "text-muted-foreground"}`}>
+                      Semanal
+                    </button>
+                    <button type="button" onClick={() => setRecurrence("biweekly")}
+                      className={`px-3 py-1 rounded-md text-[11px] font-medium transition-all ${recurrence === "biweekly" ? "bg-background shadow-sm text-foreground" : "text-muted-foreground"}`}>
+                      Quinzenal
+                    </button>
+                  </div>
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-[11px] text-muted-foreground">Quantidade</Label>
+                  <div className="flex items-center gap-2">
+                    <button type="button" onClick={() => setOccurrences((o) => Math.max(2, o - 1))}
+                      className="flex size-7 items-center justify-center rounded-lg bg-muted/50 text-sm font-medium hover:bg-muted transition-colors">−</button>
+                    <span className="text-sm font-semibold tabular-nums w-6 text-center">{occurrences}</span>
+                    <button type="button" onClick={() => setOccurrences((o) => Math.min(52, o + 1))}
+                      className="flex size-7 items-center justify-center rounded-lg bg-muted/50 text-sm font-medium hover:bg-muted transition-colors">+</button>
+                    <span className="text-[11px] text-muted-foreground">consultas</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </div>
-      <div className="flex justify-end gap-2 mt-4">
-        <Button variant="outline" onClick={onCancel} className="rounded-xl text-xs">Cancelar</Button>
-        <Button onClick={handleSubmit} disabled={!selectedPatient || !scheduleDate || !scheduleTime}
-          className="bg-vox-primary hover:bg-vox-primary/90 text-white rounded-xl text-xs">
-          {recurringEnabled ? `Agendar ${occurrences}x` : "Agendar"}
-        </Button>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pt-4 border-t border-border/30">
+        <div className="text-[11px] text-muted-foreground">
+          {!selectedPatient && "Selecione um paciente"}
+          {selectedPatient && !scheduleDate && "Escolha uma data"}
+          {selectedPatient && scheduleDate && !scheduleTime && "Escolha um horário"}
+          {canSubmit && (
+            <span className="text-vox-primary font-medium">
+              Pronto para agendar
+            </span>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={onCancel} className="rounded-xl text-xs h-8">Cancelar</Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}
+            className="bg-vox-primary hover:bg-vox-primary/90 text-white rounded-xl text-xs h-8 shadow-sm shadow-vox-primary/20">
+            {recurringEnabled ? `Agendar ${occurrences}x` : "Agendar"}
+          </Button>
+        </div>
       </div>
-    </Card>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -274,6 +274,7 @@ export default function CalendarPage() {
           notes: data.notes,
           recurrence: data.recurrence,
           occurrences: data.occurrences,
+          forceSchedule,
         })
         if ('error' in result && result.error) {
           if (result.error.startsWith("CONFLICT:")) {

--- a/src/app/(dashboard)/patients/[id]/patient-tabs.tsx
+++ b/src/app/(dashboard)/patients/[id]/patient-tabs.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import dynamic from "next/dynamic"
 import { cn } from "@/lib/utils"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Calendar,
   FileText,
@@ -17,14 +18,23 @@ import type { PatientData, CustomFieldDef, AnamnesisQuestionDef } from "./tabs/t
 
 export type { PatientData, CustomFieldDef, AnamnesisQuestionDef }
 
-const ResumoTab = dynamic(() => import("./tabs/resumo-tab"), { ssr: false })
-const HistoricoTab = dynamic(() => import("./tabs/historico-tab"), { ssr: false })
-const TratamentosTab = dynamic(() => import("./tabs/tratamentos-tab"), { ssr: false })
-const PrescricoesTab = dynamic(() => import("./tabs/prescricoes-tab"), { ssr: false })
-const DocumentosTab = dynamic(() => import("./tabs/documentos-tab"), { ssr: false })
-const GravacoesTab = dynamic(() => import("./tabs/gravacoes-tab"), { ssr: false })
-const FormulariosTab = dynamic(() => import("./tabs/formularios-tab"), { ssr: false })
-const ImagensTab = dynamic(() => import("./tabs/imagens-tab"), { ssr: false })
+function TabSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-24 w-full rounded-xl" />
+      <Skeleton className="h-48 w-full rounded-xl" />
+    </div>
+  )
+}
+
+const ResumoTab = dynamic(() => import("./tabs/resumo-tab"), { ssr: false, loading: TabSkeleton })
+const HistoricoTab = dynamic(() => import("./tabs/historico-tab"), { ssr: false, loading: TabSkeleton })
+const TratamentosTab = dynamic(() => import("./tabs/tratamentos-tab"), { ssr: false, loading: TabSkeleton })
+const PrescricoesTab = dynamic(() => import("./tabs/prescricoes-tab"), { ssr: false, loading: TabSkeleton })
+const DocumentosTab = dynamic(() => import("./tabs/documentos-tab"), { ssr: false, loading: TabSkeleton })
+const GravacoesTab = dynamic(() => import("./tabs/gravacoes-tab"), { ssr: false, loading: TabSkeleton })
+const FormulariosTab = dynamic(() => import("./tabs/formularios-tab"), { ssr: false, loading: TabSkeleton })
+const ImagensTab = dynamic(() => import("./tabs/imagens-tab"), { ssr: false, loading: TabSkeleton })
 
 const tabs = [
   { id: "resumo" as const, label: "Resumo", icon: User },
@@ -50,12 +60,14 @@ export function PatientTabs({ patient, customFields, anamnesisTemplate }: { pati
           return (
             <button
               key={tab.id}
+              id={`tab-${tab.id}`}
               onClick={() => setActiveTab(tab.id)}
               role="tab"
               aria-selected={activeTab === tab.id}
               aria-controls={`panel-${tab.id}`}
+              aria-label={tab.label}
               className={cn(
-                "flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors whitespace-nowrap",
+                "flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors whitespace-nowrap outline-none focus-visible:ring-2 focus-visible:ring-vox-primary/50 focus-visible:ring-offset-1",
                 activeTab === tab.id
                   ? "bg-background shadow-sm"
                   : "text-muted-foreground hover:text-foreground"
@@ -68,7 +80,7 @@ export function PatientTabs({ patient, customFields, anamnesisTemplate }: { pati
         })}
       </div>
 
-      <div role="tabpanel" id={`panel-${activeTab}`} aria-label={tabs.find(t => t.id === activeTab)?.label}>
+      <div role="tabpanel" id={`panel-${activeTab}`} aria-labelledby={`tab-${activeTab}`}>
         {activeTab === "resumo" && <ResumoTab patient={patient} customFields={customFields} />}
         {activeTab === "historico" && <HistoricoTab appointments={patient.appointments} patientId={patient.id} />}
         {activeTab === "tratamentos" && <TratamentosTab patientId={patient.id} />}

--- a/src/app/(dashboard)/patients/[id]/tabs/documentos-tab.tsx
+++ b/src/app/(dashboard)/patients/[id]/tabs/documentos-tab.tsx
@@ -115,59 +115,54 @@ export default function DocumentosTab({ patientId }: { patientId: string }) {
 
   return (
     <div className="space-y-4">
-      {/* Upload area */}
-      <div
-        onClick={() => !uploading && fileInputRef.current?.click()}
-        className={cn(
-          "group flex flex-col items-center gap-2 rounded-2xl border-2 border-dashed p-6 text-center cursor-pointer transition-all",
-          uploading
-            ? "border-vox-primary/30 bg-vox-primary/5"
-            : "border-border/50 hover:border-vox-primary/40 hover:bg-vox-primary/[0.02]"
-        )}
-      >
-        {uploading ? (
-          <Loader2 className="size-6 text-vox-primary animate-spin" />
-        ) : (
-          <Upload className="size-6 text-muted-foreground/50 group-hover:text-vox-primary transition-colors" />
-        )}
-        <div>
-          <p className="text-sm font-medium">{uploading ? "Enviando..." : "Enviar documento"}</p>
-          <p className="text-[11px] text-muted-foreground mt-0.5">
-            Imagens, PDF ou Word — max 10MB
-          </p>
-        </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          multiple
-          accept="image/*,.pdf,.doc,.docx"
-          onChange={handleUpload}
-          className="hidden"
-        />
-      </div>
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept="image/*,.pdf,.doc,.docx"
+        onChange={handleUpload}
+        className="hidden"
+      />
 
-      {/* Document grid */}
       {docs.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 py-8 text-center">
-          <div className="flex size-14 items-center justify-center rounded-full bg-muted/60">
-            <FileImage className="size-6 text-muted-foreground/50" />
-          </div>
+        <div
+          onClick={() => !uploading && fileInputRef.current?.click()}
+          className={cn(
+            "group flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed py-12 text-center cursor-pointer transition-all",
+            uploading
+              ? "border-vox-primary/30 bg-vox-primary/5"
+              : "border-border/50 hover:border-vox-primary/40 hover:bg-vox-primary/[0.02]"
+          )}
+        >
+          {uploading ? (
+            <Loader2 className="size-8 text-vox-primary animate-spin" />
+          ) : (
+            <div className="flex size-14 items-center justify-center rounded-full bg-muted/60 group-hover:bg-vox-primary/10 transition-colors">
+              <Upload className="size-6 text-muted-foreground/50 group-hover:text-vox-primary transition-colors" />
+            </div>
+          )}
           <div>
-            <p className="text-sm font-medium">Nenhum documento anexado</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Envie imagens, PDFs ou documentos do paciente
+            <p className="text-sm font-medium">{uploading ? "Enviando..." : "Enviar documento"}</p>
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              Arraste ou clique — Imagens, PDF ou Word — max 10MB
             </p>
           </div>
-          <Button
-            size="sm"
-            onClick={() => fileInputRef.current?.click()}
-            className="bg-vox-primary text-white hover:bg-vox-primary/90 gap-1.5 mt-1"
-          >
-            <Upload className="size-3.5" />
-            Fazer upload
-          </Button>
         </div>
       ) : (
+        <>
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => !uploading && fileInputRef.current?.click()}
+            disabled={uploading}
+            className="gap-1.5 rounded-xl text-xs"
+          >
+            {uploading ? <Loader2 className="size-3.5 animate-spin" /> : <Upload className="size-3.5" />}
+            {uploading ? "Enviando..." : "Enviar documento"}
+          </Button>
+        </div>
         <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
           {docs.map((doc) => (
             <Card key={doc.id} className="group overflow-hidden">
@@ -208,6 +203,7 @@ export default function DocumentosTab({ patientId }: { patientId: string }) {
             </Card>
           ))}
         </div>
+        </>
       )}
       <ConfirmDialog
         open={confirmDialog.open}

--- a/src/app/(dashboard)/patients/[id]/tabs/resumo-tab.tsx
+++ b/src/app/(dashboard)/patients/[id]/tabs/resumo-tab.tsx
@@ -212,27 +212,75 @@ export default function ResumoTab({ patient, customFields }: { patient: PatientD
     return new Date(date).toLocaleDateString("pt-BR")
   }
 
+  // Quick stats
+  const appointmentCount = patient.appointments?.length ?? 0
+  const recordingCount = patient.recordings?.length ?? 0
+  const lastAppointment = patient.appointments?.[0]
+  const lastAppointmentDate = lastAppointment ? new Date(lastAppointment.date).toLocaleDateString("pt-BR") : null
+
   return (
     <div className="space-y-4">
-      {balance && balance.total > 0 && (
-        <div className="flex items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
-          <AlertTriangle className="size-4 text-amber-600" />
-          <span className="text-amber-800">
-            Saldo devedor: <strong>R$ {(balance.total / 100).toFixed(2).replace(".", ",")}</strong>
-            {balance.overdue > 0 && (
-              <span className="text-red-600 ml-1">(R$ {(balance.overdue / 100).toFixed(2).replace(".", ",")} vencido)</span>
-            )}
-          </span>
+      {/* Quick Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="flex items-center gap-2.5 rounded-xl bg-muted/30 border border-border/30 px-3 py-2">
+          <div className="flex size-7 items-center justify-center rounded-lg bg-vox-primary/10 shrink-0">
+            <User className="size-3.5 text-vox-primary" />
+          </div>
+          <div>
+            <p className="text-[16px] font-bold tabular-nums leading-none">{appointmentCount}</p>
+            <p className="text-[10px] text-muted-foreground mt-0.5">Consultas</p>
+          </div>
         </div>
-      )}
+        <div className="flex items-center gap-2.5 rounded-xl bg-muted/30 border border-border/30 px-3 py-2">
+          <div className="flex size-7 items-center justify-center rounded-lg bg-vox-primary/10 shrink-0">
+            <Heart className="size-3.5 text-vox-primary" />
+          </div>
+          <div>
+            <p className="text-[12px] font-semibold leading-none">{lastAppointmentDate ?? "—"}</p>
+            <p className="text-[10px] text-muted-foreground mt-0.5">Última visita</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2.5 rounded-xl bg-muted/30 border border-border/30 px-3 py-2">
+          <div className="flex size-7 items-center justify-center rounded-lg bg-vox-primary/10 shrink-0">
+            <MessageSquare className="size-3.5 text-vox-primary" />
+          </div>
+          <div>
+            <p className="text-[16px] font-bold tabular-nums leading-none">{recordingCount}</p>
+            <p className="text-[10px] text-muted-foreground mt-0.5">Gravações</p>
+          </div>
+        </div>
+        {balance && balance.total > 0 ? (
+          <div className="flex items-center gap-2.5 rounded-xl bg-vox-warning/5 border border-vox-warning/20 px-3 py-2">
+            <div className="flex size-7 items-center justify-center rounded-lg bg-vox-warning/10 shrink-0">
+              <AlertTriangle className="size-3.5 text-vox-warning" />
+            </div>
+            <div>
+              <p className="text-[12px] font-bold text-vox-warning leading-none">R$ {(balance.total / 100).toFixed(2).replace(".", ",")}</p>
+              <p className="text-[10px] text-muted-foreground mt-0.5">Saldo devedor</p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2.5 rounded-xl bg-muted/30 border border-border/30 px-3 py-2">
+            <div className="flex size-7 items-center justify-center rounded-lg bg-vox-success/10 shrink-0">
+              <Shield className="size-3.5 text-vox-success" />
+            </div>
+            <div>
+              <p className="text-[12px] font-semibold text-vox-success leading-none">Em dia</p>
+              <p className="text-[10px] text-muted-foreground mt-0.5">Financeiro</p>
+            </div>
+          </div>
+        )}
+      </div>
+
     <Card>
-      <CardHeader className="flex-row items-center justify-between">
-        <CardTitle>Dados Pessoais</CardTitle>
+      <CardHeader className="flex-row items-center justify-between pb-3">
+        <CardTitle className="text-sm">Dados Pessoais</CardTitle>
         <Button
           variant="outline"
           size="sm"
           onClick={() => (isEditing ? handleSave() : setIsEditing(true))}
           disabled={saving}
+          className="h-7 text-xs rounded-lg"
         >
           {saving ? "Salvando..." : isEditing ? "Salvar" : "Editar"}
         </Button>
@@ -277,33 +325,50 @@ export default function ResumoTab({ patient, customFields }: { patient: PatientD
 
           return (
             <>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {fieldsToShow.map((field) => {
-                  const IconComp = (field as any).icon
-                  return (
-                    <div key={field.id} className="space-y-1.5">
-                      <Label className={IconComp ? "flex items-center gap-1.5" : undefined}>
-                        {IconComp && <IconComp className="size-3.5" />}
-                        {field.label}
-                      </Label>
-                      {isEditing && !field.readOnly ? (
-                        field.editEl
-                      ) : (
-                        <p className="text-sm">{field.value || "-"}</p>
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
+              {isEditing ? (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {fieldsToShow.map((field) => {
+                    const IconComp = (field as any).icon
+                    return (
+                      <div key={field.id} className="space-y-1.5">
+                        <Label className={IconComp ? "flex items-center gap-1.5" : undefined}>
+                          {IconComp && <IconComp className="size-3.5" />}
+                          {field.label}
+                        </Label>
+                        {field.readOnly ? (
+                          <p className="text-sm text-muted-foreground">{field.value || "—"}</p>
+                        ) : (
+                          field.editEl
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              ) : (
+                <div className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+                  {fieldsToShow.map((field) => {
+                    const IconComp = (field as any).icon
+                    return (
+                      <div key={field.id} className="flex items-baseline gap-2 py-1 border-b border-border/20 last:border-0">
+                        <span className="text-[12px] text-muted-foreground shrink-0 flex items-center gap-1">
+                          {IconComp && <IconComp className="size-3" />}
+                          {field.label}
+                        </span>
+                        <span className="text-[13px] font-medium ml-auto text-right">{field.value || "—"}</span>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
               {!isEditing && hiddenCount > 0 && (
                 <button
                   type="button"
                   onClick={() => setShowAllFields(!showAllFields)}
-                  className="text-xs text-vox-primary hover:text-vox-primary/80 transition-colors font-medium"
+                  className="text-[11px] text-vox-primary hover:text-vox-primary/80 transition-colors font-medium mt-1"
                 >
                   {showAllFields
                     ? "Ocultar campos vazios"
-                    : `Mostrar todos (${hiddenCount} campos ocultos)`}
+                    : `+ ${hiddenCount} campos`}
                 </button>
               )}
             </>
@@ -464,7 +529,7 @@ export default function ResumoTab({ patient, customFields }: { patient: PatientD
                       )}
                     </Badge>
                   ))}
-                  {items.length === 0 && !isEditing && <span className="text-xs text-muted-foreground">-</span>}
+                  {items.length === 0 && !isEditing && <span className="text-[11px] text-muted-foreground/60 italic">Não informado</span>}
                 </div>
                 {isEditing && (
                   <div className="flex gap-2">
@@ -483,7 +548,7 @@ export default function ResumoTab({ patient, customFields }: { patient: PatientD
                 {["A+","A-","B+","B-","AB+","AB-","O+","O-"].map(t => <option key={t} value={t}>{t}</option>)}
               </select>
             ) : (
-              <p className="text-sm">{(medicalHistory.bloodType as string) || "-"}</p>
+              <p className="text-sm">{(medicalHistory.bloodType as string) || <span className="text-muted-foreground/60 italic text-[11px]">Não informado</span>}</p>
             )}
           </div>
           <div className="space-y-1">
@@ -491,14 +556,17 @@ export default function ResumoTab({ patient, customFields }: { patient: PatientD
             {isEditing ? (
               <Textarea value={(medicalHistory.notes as string) ?? ""} onChange={(e) => setMedicalHistory({ ...medicalHistory, notes: e.target.value || null })} placeholder="Observacoes gerais..." className="text-xs" rows={2} />
             ) : (
-              <p className="text-sm">{(medicalHistory.notes as string) || "-"}</p>
+              <p className="text-sm">{(medicalHistory.notes as string) || <span className="text-muted-foreground/60 italic text-[11px]">Nenhuma observação</span>}</p>
             )}
           </div>
         </div>
 
         {/* Alerts */}
-        <div className="rounded-lg border border-vox-error/30 bg-vox-error/5 p-3 space-y-1.5">
-          <p className="text-sm font-medium text-vox-error">Alertas</p>
+        <div className={`rounded-lg border p-3 space-y-1.5 ${alerts.length > 0 || isEditing ? "border-vox-error/30 bg-vox-error/5" : "border-border/30 bg-muted/20"}`}>
+          <p className={`text-sm font-medium flex items-center gap-1.5 ${alerts.length > 0 || isEditing ? "text-vox-error" : "text-muted-foreground"}`}>
+            <AlertTriangle className="size-3.5" />
+            Alertas
+          </p>
           {isEditing ? (
             <div className="space-y-2">
               <div className="flex flex-wrap gap-1.5">

--- a/src/server/actions/appointment.ts
+++ b/src/server/actions/appointment.ts
@@ -694,6 +694,7 @@ export const scheduleRecurringAppointments = safeAction(async (data: {
   procedures?: string[]
   recurrence: "weekly" | "biweekly"
   occurrences: number
+  forceSchedule?: boolean
 }) => {
   const workspaceId = await getWorkspaceId()
   requirePermission(await getRole(), "appointments.create")
@@ -745,14 +746,16 @@ export const scheduleRecurringAppointments = safeAction(async (data: {
           date: { gte: new Date(date.getTime() - windowMs), lte: new Date(date.getTime() + windowMs) },
         },
       })
-      if (conflicts.length > 0) {
+      if (conflicts.length > 0 && !data.forceSchedule) {
         throw new ActionError(`CONFLICT:Conflito no horário ${date.toLocaleDateString("pt-BR")} ${date.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}`)
       }
 
       // Check blocked slots (one-time + recurring weekly)
-      const blockedConflict = await findBlockedSlotConflict(tx, workspaceId, data.agendaId, date, slotDuration)
-      if (blockedConflict) {
-        throw new ActionError(`CONFLICT:Horário bloqueado em ${date.toLocaleDateString("pt-BR")}: ${blockedConflict}`)
+      if (!data.forceSchedule) {
+        const blockedConflict = await findBlockedSlotConflict(tx, workspaceId, data.agendaId, date, slotDuration)
+        if (blockedConflict) {
+          throw new ActionError(`CONFLICT:Horário bloqueado em ${date.toLocaleDateString("pt-BR")}: ${blockedConflict}`)
+        }
       }
 
       results.push(await tx.appointment.create({


### PR DESCRIPTION
## Summary

Substitui PRs #43 e #44 (que não foram merged). Inclui todas as melhorias + correções adicionais.

### Schedule Form → Dialog modal
- Convertido de card inline para Dialog (calendário fica visível)
- Date shortcuts (Hoje, Amanhã, próximos dias) + time agrupado por Manhã/Tarde/Noite
- Agenda selector com color dots, steps numerados, hint contextual no footer
- **Bug fix**: recurring schedule conflict loop infinito (forceSchedule não era passado)

### Patient Detail
- Quick stats row no topo do Resumo (consultas, última visita, gravações, financeiro)
- Layout compacto key:value em modo leitura
- Empty states melhorados ("Não informado" em vez de "-")
- Alertas sem borda vermelha quando vazio
- Skeleton loading em todas as 8 tabs

### Documents Tab
- Upload duplicado removido (era dropzone + botão "Fazer upload")
- Empty: dropzone único clicável. Com docs: botão compacto acima da grid

### New Consultation (Recording)
- Mic em card com background, header com back + patient badge
- 6 cards de hints (Procedimentos, Observações, Prescrições, Recomendações, Alertas, Próximos passos)

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 427/427 passing
- [ ] Testar agendamento: dialog abre, date shortcuts, time picker, recurring com conflito
- [ ] Testar patient detail: quick stats, layout compacto, alertas vazio vs preenchido
- [ ] Testar documents: upload empty state, upload com docs existentes
- [ ] Testar nova consulta: hints visíveis, mic funcional, trocar paciente

**Nota**: PRs #43 e #44 podem ser fechados após merge deste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)